### PR TITLE
Feature/SER-1406- Add user's country Id to the field address request

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+Release Notes
+
+## Unreleased
+
+    * [SER-1406] - Fix create client errors
+
 ## Version 1.0.0 - for use with Fineract Web App
 
     * This repository was forked from Mifos Web App

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -266,8 +266,8 @@ export class ClientsService {
     return this.http.delete(`/clients/${clientId}/notes/${noteId}`);
   }
 
-  getAddressFieldConfiguration() {
-    return this.http.get(`/fieldconfiguration/ADDRESS`);
+  getAddressFieldConfiguration(countryId: number) {
+    return this.http.get(`/fieldconfiguration/ADDRESS/${countryId}`);
   }
 
   getClientAddressData(clientId: string) {

--- a/src/app/clients/common-resolvers/client-address-fieldconfiguration.resolver.ts
+++ b/src/app/clients/common-resolvers/client-address-fieldconfiguration.resolver.ts
@@ -24,7 +24,8 @@ export class ClientAddressFieldConfigurationResolver implements Resolve<Object> 
      * @returns {Observable<any>}
      */
     resolve(): Observable<any> {
-        return this.clientsService.getAddressFieldConfiguration();
+        const countryId = JSON.parse(sessionStorage.getItem('mifosXCredentials')).countryId;
+        return this.clientsService.getAddressFieldConfiguration(countryId);
     }
 
 }

--- a/src/app/core/authentication/credentials.model.ts
+++ b/src/app/core/authentication/credentials.model.ts
@@ -17,4 +17,5 @@ export interface Credentials {
   username: string;
   shouldRenewPassword: boolean;
   rememberMe?: boolean;
+  countryId?: number;
 }


### PR DESCRIPTION
## Description
Added the country ID when making a request as the endpoint changed to get field address per country

Can be tested here: [dev cluster](http://65.108.247.228:31506/)

## Changes Included in PR
- [{first-ticket-number} - {first-ticket-description}]({link-to-Jira-ticket})
- [{second-ticket-number} - {second-ticket-description}]({link-to-Jira-ticket})

## PR Checklist
- [ ] Xray tests created
- [ ] PM tested and approved
- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`

## Screenshots, if any

.
