### PR TITLE
[SER-842] Allow an admin to select a country and make any changes to it

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 ## Unreleased
 
     * [SER-1406] - Fix create client errors
+    * [SER-842] - Allow an authorised user to select an active country so that s/he can make any changes to a specific country
 
 ## Version 1.0.0 - for use with Fineract Web App
 

--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -17,11 +17,12 @@
     </a>
     <a mat-tab-link class="tab-link" *ngIf="displayAdminOptions">
       <mat-select class="mr-2" #countryId required formControlName="countryId">
-        <mat-option *ngFor="let country of activeCountries" [value]="country.id" (click)="saveTheSelectedCountry(country.id)">
+        <mat-option *ngFor="let country of activeCountries" [value]="country.id" (click)="saveTheSelectedCountry(country)">
           {{country.name}}
         </mat-option>
       </mat-select>
-      {{ 'Country' | translate }}
+      <mat-label *ngIf="!selectedCountryName">{{ 'Country' | translate }}</mat-label>
+      <mat-label *ngIf="selectedCountryName">{{selectedCountryName}}</mat-label>
     </a>
 
     <span fxHide.lt-lg="true">

--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -15,6 +15,14 @@
       <fa-icon class="mr-05" icon="university" size="lg"></fa-icon>
       {{ 'Institution' | translate }}
     </a>
+    <a mat-tab-link class="tab-link" *ngIf="displayAdminOptions">
+      <mat-select class="mr-2" #countryId required formControlName="countryId">
+        <mat-option *ngFor="let country of activeCountries" [value]="country.id" (click)="saveTheSelectedCountry(country.id)">
+          {{country.name}}
+        </mat-option>
+      </mat-select>
+      {{ 'Country' | translate }}
+    </a>
 
     <span fxHide.lt-lg="true">
 
@@ -26,7 +34,7 @@
         <fa-icon class="mr-05" icon="chart-bar" size="lg"></fa-icon>
         {{ 'Reports' | translate }}
       </a>
-      <a mat-tab-link class="tab-link" [matMenuTriggerFor]="adminMenu" #adminMenuTrigger="matMenuTrigger">
+      <a mat-tab-link class="tab-link" [matMenuTriggerFor]="adminMenu" #adminMenuTrigger="matMenuTrigger" *ngIf="displayAdminOptions">
         <fa-icon class="mr-05" icon="shield-alt" size="lg"></fa-icon>
         {{ 'Admin' | translate }}
       </a>

--- a/src/app/core/shell/toolbar/toolbar.component.scss
+++ b/src/app/core/shell/toolbar/toolbar.component.scss
@@ -37,4 +37,8 @@
   .mr-1 {
     margin-right: 1rem;
   }
+
+  .mr-2 {
+    margin-right: 0.2rem;
+  }
 }

--- a/src/app/core/shell/toolbar/toolbar.component.ts
+++ b/src/app/core/shell/toolbar/toolbar.component.ts
@@ -38,6 +38,9 @@ export class ToolbarComponent implements OnInit {
   /** Limit the checks when it has already did. */
   hasChecked: boolean = false;
 
+  /** Get the selected country name if it is set */
+  selectedCountryName: any;
+
   /** Subscription to breakpoint observer for handset. */
   isHandset$: Observable<boolean> = this.breakpointObserver.observe(Breakpoints.Handset)
     .pipe(
@@ -79,13 +82,15 @@ export class ToolbarComponent implements OnInit {
     
     if(!this.hasChecked && this.userData?.permissions.length > 0) {
       let hasAnyPermission = this.allowedPermissions.filter(item => this.userData.permissions.includes(item)).length > 0;
-
       if(hasAnyPermission) {
         this.getActiveCountries();
         this.displayAdminOptions = true;
       }
-
       this.hasChecked = true;
+    }
+
+    if(this.displayAdminOptions) {
+      this.selectedCountryName = JSON.parse(sessionStorage.getItem("selectedCountry"))?.name;
     }
   }
   
@@ -101,8 +106,8 @@ export class ToolbarComponent implements OnInit {
   /**
    * Saves the selected country id in the session storage.
    */
-  saveTheSelectedCountry(countryId: any) {
-    sessionStorage.setItem('selectedCountryId', countryId); 
+  saveTheSelectedCountry(country: any) {
+    sessionStorage.setItem('selectedCountry', JSON.stringify({countryId: country.id, name: country.name}));
   }
       
   /**

--- a/src/app/core/shell/toolbar/toolbar.component.ts
+++ b/src/app/core/shell/toolbar/toolbar.component.ts
@@ -11,6 +11,7 @@ import { map } from 'rxjs/operators';
 
 /** Custom Services */
 import { AuthenticationService } from '../../authentication/authentication.service';
+import { OrganizationService } from 'app/organization/organization.service';
 
 /**
  * Toolbar component.
@@ -21,6 +22,21 @@ import { AuthenticationService } from '../../authentication/authentication.servi
   styleUrls: ['./toolbar.component.scss']
 })
 export class ToolbarComponent implements OnInit {
+
+  /** Eligible permissions to view the country dropdown and an admin menu. */
+  allowedPermissions: any = ["ALL_FUNCTIONS"];
+
+  /** Save the user data from the session storage. */
+  userData: any;
+
+  /** Allow an authorised user to select a country and view an Admin menu. */
+  displayAdminOptions: boolean = false;
+  
+  /** Only active countries. */
+  activeCountries: any = [];
+
+  /** Limit the checks when it has already did. */
+  hasChecked: boolean = false;
 
   /** Subscription to breakpoint observer for handset. */
   isHandset$: Observable<boolean> = this.breakpointObserver.observe(Breakpoints.Handset)
@@ -42,9 +58,10 @@ export class ToolbarComponent implements OnInit {
    * @param {AuthenticationService} authenticationService Authentication service.
    */
   constructor(private breakpointObserver: BreakpointObserver,
-              private router: Router,
-              private authenticationService: AuthenticationService,
-              private dialog: MatDialog) { }
+    private router: Router,
+    private authenticationService: AuthenticationService,
+    private organizationService: OrganizationService,
+    private dialog: MatDialog) {}
 
   /**
    * Subscribes to breakpoint for handset.
@@ -57,6 +74,37 @@ export class ToolbarComponent implements OnInit {
     });
   }
 
+  ngDoCheck() {
+    this.userData = this.authenticationService.getCredentials();
+    
+    if(!this.hasChecked && this.userData?.permissions.length > 0) {
+      let hasAnyPermission = this.allowedPermissions.filter(item => this.userData.permissions.includes(item)).length > 0;
+
+      if(hasAnyPermission) {
+        this.getActiveCountries();
+        this.displayAdminOptions = true;
+      }
+
+      this.hasChecked = true;
+    }
+  }
+  
+  /**
+  * List active countries.
+  */
+  getActiveCountries() {
+    this.organizationService.getCountries().subscribe((response: any) => {
+      this.activeCountries = response?.filter(item => item.status);
+    });
+  }
+
+  /**
+   * Saves the selected country id in the session storage.
+   */
+  saveTheSelectedCountry(countryId: any) {
+    sessionStorage.setItem('selectedCountryId', countryId); 
+  }
+      
   /**
    * Toggles the current state of sidenav.
    */
@@ -77,7 +125,7 @@ export class ToolbarComponent implements OnInit {
    */
   logout() {
     this.authenticationService.logout();
-      // .subscribe(() => this.router.navigate(['/login'], { replaceUrl: true }));
+    // .subscribe(() => this.router.navigate(['/login'], { replaceUrl: true }));
   }
 
   /**

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -18,5 +18,6 @@
   "Self Service": "Self Service",
   "Institution": "Institution",
   "Language": "Language",
-  "Server": "Server"
+  "Server": "Server",
+  "Country": "Country"
 }

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -18,5 +18,6 @@
   "Self Service": "En libre service",
   "Institution": "Institution",
   "Language": "Langue",
-  "Server": "Serveur"
+  "Server": "Serveur",
+  "Country": "Pays"
 }


### PR DESCRIPTION
## Description
- Declare allowed permissions for the global and country admins so that they can view active countries and select one so that they can make any changes to a specific country

## Changes Included in PR
- [SER-842](https://oneacrefund.atlassian.net/browse/SER-842)

## Screenshots, if any

### Display country drop-down and an admin menu for only allowed users 
<img width="1510" alt="Screenshot 2023-02-13 at 11 20 02 AM" src="https://user-images.githubusercontent.com/40672143/218426743-9a3f4f2b-a717-491e-af95-800e3fde5d45.png">

### Save the `country` details in the session storage for future use 
<img width="1505" alt="Screenshot 2023-02-13 at 3 23 17 PM" src="https://user-images.githubusercontent.com/40672143/218470142-906c9dd8-9956-403b-890e-dc55df59d0e5.png">


[SER-842]: https://oneacrefund.atlassian.net/browse/SER-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ