### PR TITLE
fix: Remove templates link to organization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,6 +68,7 @@
     * [SER-2537] - Add country link to SMS campaigns
     * [SER-2809] - Fix navigations in the group view interface
     * [SER-2507] - Require OTP validation when updating clients
+    * [SER-2818] - Remove templates link to organisation.
 
 ## Version 1.0.0 - for use with Fineract Web App
 

--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -19,7 +19,7 @@
       <div class="form-group">
         <select class="form-control" id="countryId" (change)="saveTheSelectedCountry($event.target.value)">
           <option value="" selected disabled hidden>
-            {{ selectedCountryName ? selectedCountryName : "Select Country" }}
+            {{ selectedCountryName ? selectedCountryName : 'Select Country' }}
           </option>
           <option *ngFor="let country of activeCountries" [value]="country.id">{{ country.name }}</option>
         </select>
@@ -34,7 +34,7 @@
       *ngIf="(selectedCountryName && displayAdminOptions) || !displayAdminOptions"
     >
       <fa-icon class="mr-05" icon="university" size="lg"></fa-icon>
-      {{ "Institution" | translate }}
+      {{ 'Institution' | translate }}
     </a>
 
     <a
@@ -44,7 +44,7 @@
       [routerLink]="['/organization']"
     >
       <fa-icon class="mr-05" icon="building" size="lg"></fa-icon>
-      {{ "Organization" | translate }}
+      {{ 'Organization' | translate }}
     </a>
 
     <a
@@ -54,7 +54,7 @@
       [routerLink]="['/products']"
     >
       <fa-icon class="mr-05" icon="book" size="lg"></fa-icon>
-      {{ "Products" | translate }}
+      {{ 'Products' | translate }}
     </a>
 
     <span fxHide.lt-lg="true" *ngIf="(selectedCountryName && displayAdminOptions) || !displayAdminOptions">
@@ -74,7 +74,7 @@
         *ngIf="displayAdminOptions"
       >
         <fa-icon class="mr-05" icon="shield-alt" size="lg"></fa-icon>
-        {{ "Admin" | translate }}
+        {{ 'Admin' | translate }}
       </a>
       <!--   <a mat-tab-link class="tab-link" [matMenuTriggerFor]="selfServiceMenu" #selfServiceMenuTrigger="matMenuTrigger">
         <fa-icon class="mr-05" icon="users" size="lg"></fa-icon>
@@ -126,7 +126,7 @@
   <!-- <button mat-menu-item [routerLink]="['/organization']">Organization</button> -->
   <button mat-menu-item [routerLink]="['/system']">System</button>
   <!--  <button mat-menu-item [routerLink]="['/products']">Products</button> -->
-  <button mat-menu-item [routerLink]="['/templates']">Templates</button>
+  <!-- <button mat-menu-item [routerLink]="['/templates']">Templates</button> -->
 </mat-menu>
 
 <mat-menu #selfServiceMenu="matMenu" [overlapTrigger]="false">

--- a/src/app/organization/organization.component.html
+++ b/src/app/organization/organization.component.html
@@ -1,13 +1,8 @@
 <div class="container">
-
   <mat-card>
-
     <div fxLayout="row" fxLayout.lt-md="column">
-
       <div fxFlex="50%">
-
         <mat-nav-list>
-
           <mat-list-item [routerLink]="['offices']" *mifosxHasPermission="'READ_OFFICE'">
             <mat-icon matListIcon>
               <fa-icon icon="building" size="sm"></fa-icon>
@@ -38,7 +33,10 @@
             <p matLine>An employee represents loan officers with no access to systems</p>
           </mat-list-item>
 
-          <mat-list-item [routerLink]="['standing-instructions-history']" *mifosxHasPermission="'READ_STANDINGINSTRUCTION'">
+          <mat-list-item
+            [routerLink]="['standing-instructions-history']"
+            *mifosxHasPermission="'READ_STANDINGINSTRUCTION'"
+          >
             <mat-icon matListIcon>
               <fa-icon icon="book" size="sm"></fa-icon>
             </mat-icon>
@@ -54,7 +52,10 @@
             <p matLine>Bulk entry screen for mapping fund sources to loans</p>
           </mat-list-item>
 
-          <mat-list-item [routerLink]="['password-preferences']" *mifosxHasPermission="'READ_PASSWORD_VALIDATION_POLICY'">
+          <mat-list-item
+            [routerLink]="['password-preferences']"
+            *mifosxHasPermission="'READ_PASSWORD_VALIDATION_POLICY'"
+          >
             <mat-icon matListIcon>
               <fa-icon icon="lock" size="sm"></fa-icon>
             </mat-icon>
@@ -70,22 +71,29 @@
             <p matLine>Define Loan Provisioning Criteria for Organization</p>
           </mat-list-item>
 
-          <mat-list-item [routerLink]="['entity-data-table-checks']" *mifosxHasPermission="'READ_ENTITY_DATATABLE_CHECK'">
+          <mat-list-item
+            [routerLink]="['entity-data-table-checks']"
+            *mifosxHasPermission="'READ_ENTITY_DATATABLE_CHECK'"
+          >
             <mat-icon matListIcon>
               <fa-icon icon="check" size="sm"></fa-icon>
             </mat-icon>
-            <h4 matLine>Entity Data Table Checks </h4>
+            <h4 matLine>Entity Data Table Checks</h4>
             <p matLine>Define Entity Data Table Checks for Organization</p>
           </mat-list-item>
 
+          <mat-list-item [routerLink]="['/templates']" *mifosxHasPermission="'READ_TEMPLATE'">
+            <mat-icon matListIcon>
+              <fa-icon icon="envelope" size="sm"></fa-icon>
+            </mat-icon>
+            <h4 matLine>Templates</h4>
+            <p matLine>Create terms and conditions, etc.</p>
+          </mat-list-item>
         </mat-nav-list>
-
       </div>
 
       <div fxFlex="50%">
-
         <mat-nav-list>
-
           <mat-list-item [routerLink]="['currencies']" *mifosxHasPermission="'READ_CURRENCY'">
             <mat-icon matListIcon>
               <fa-icon icon="cogs" size="sm"></fa-icon>
@@ -93,7 +101,6 @@
             <h4 matLine>Currency Configuration</h4>
             <p matLine>Currencies available across organization for different products</p>
           </mat-list-item>
-
 
           <mat-list-item [routerLink]="['manage-funds']" *mifosxHasPermission="'READ_FUND'">
             <mat-icon matListIcon>
@@ -151,20 +158,15 @@
             <p matLine>Define AdHocQuery for Organization</p>
           </mat-list-item>
 
-          <mat-list-item [routerLink]="['bulk-import']" *mifosxHasPermission="'VIEW_BULKIMPORT'">
+          <mat-list-item [routerLink]="['bulk-import']" *mifosxHasPermission="'READ_CLIENT'">
             <mat-icon matListIcon>
               <fa-icon icon="upload" size="sm"></fa-icon>
             </mat-icon>
             <h4 matLine>Bulk Import</h4>
             <p matLine>Bulk data import using excel spreadsheet templates for clients, offices, etc.</p>
           </mat-list-item>
-
         </mat-nav-list>
-
       </div>
-
     </div>
-
   </mat-card>
-
 </div>


### PR DESCRIPTION
## Description
Remove the template link from the admin section to Organisation links.

## Changes Included in PR
- https://oneacrefund.atlassian.net/browse/SER-2818

## PR Checklist
- [ ] Xray tests created
- [ ] PM tested and approved
- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`

## Screenshots, if any

<img width="864" alt="image" src="https://github.com/one-acre-fund/fineract-frontend-v2/assets/124994/f4b54923-8b7a-480e-a97f-de3d76e9cec1">


.
