### PR TITLE
feat(SER-2859) Add a new field(string value) on the config page

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@
 
     * [SER-2854] - Removed currency control subscription on charges step during loan product update that clears charges on currency change
 
+## Version 1.3.1 - Community 1.0.0
+    * [SER-2859] - Accept a string value to be passed when creating a new configuration, but only for the 'skip-ocr-credit-score-users' config at this time.
 ## Version 1.3.0 - Community 1.0.0
 
     * [SER-1406] - Fix create client errors

--- a/src/app/system/configurations/global-configurations-tab/clone-configuration/clone-configuration.component.html
+++ b/src/app/system/configurations/global-configurations-tab/clone-configuration/clone-configuration.component.html
@@ -14,6 +14,11 @@
                 Value is <strong>required</strong>
               </mat-error>
             </mat-form-field>
+
+            <mat-form-field *ngIf="!configuration.codeId">
+              <mat-label>String Value</mat-label>
+              <input type="string" matInput formControlName="stringValue">
+            </mat-form-field>
             <!-- <mat-form-field>
                 <mat-label>Country</mat-label>
                 <mat-select placeholder="Search" #country required formControlName="countryId">

--- a/src/app/system/configurations/global-configurations-tab/clone-configuration/clone-configuration.component.html
+++ b/src/app/system/configurations/global-configurations-tab/clone-configuration/clone-configuration.component.html
@@ -7,17 +7,20 @@
       <form [formGroup]="configurationForm" (ngSubmit)="submit()">
         <mat-card-content>
           <div fxLayout="column">
-            <mat-form-field *ngIf="!configuration.codeId">
+            <mat-form-field *ngIf="!configuration.codeId && !stringValueConfigs.includes(configuration.name)">
               <mat-label>Value</mat-label>
-              <input type="number" matInput required formControlName="value">
+              <input type="number" matInput [required]="!stringValueConfigs.includes(configuration.name)" formControlName="value">
               <mat-error *ngIf="configurationForm.controls.value.hasError('required')">
                 Value is <strong>required</strong>
               </mat-error>
             </mat-form-field>
 
-            <mat-form-field *ngIf="!configuration.codeId">
+            <mat-form-field *ngIf="!configuration.codeId && stringValueConfigs.includes(configuration.name)">
               <mat-label>String Value</mat-label>
-              <input type="string" matInput formControlName="stringValue">
+              <input type="string" matInput [required]="stringValueConfigs.includes(configuration.name)" formControlName="stringValue">
+              <mat-error *ngIf="configurationForm.controls.stringValue.hasError('required')">
+                String Value is <strong>required</strong>
+              </mat-error>
             </mat-form-field>
             <!-- <mat-form-field>
                 <mat-label>Country</mat-label>

--- a/src/app/system/configurations/global-configurations-tab/clone-configuration/clone-configuration.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/clone-configuration/clone-configuration.component.ts
@@ -14,7 +14,8 @@ export class CloneConfigurationComponent implements OnInit {
   private readonly configLevels: Record<string, any> = {
     "payment-channel": "payment-channel-ou-level"
   };
-
+  /** Default config for string value */
+  stringValueConfigs: string[] = ["skip-ocr-credit-score-users"];
   /** Global Configuration form. */
   configurationForm: UntypedFormGroup;
   /** Configuration. */
@@ -63,7 +64,7 @@ export class CloneConfigurationComponent implements OnInit {
       countryId = this.configuration.country.id;
     }
     this.configurationForm = this.formBuilder.group({
-      value: ['', !this.configuration.codeId ? Validators.required : null],
+      value: [null],
       stringValue: [null],
       countryId: [countryId, Validators.required],
       globalConfigId: [this.configId],

--- a/src/app/system/configurations/global-configurations-tab/clone-configuration/clone-configuration.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/clone-configuration/clone-configuration.component.ts
@@ -64,6 +64,7 @@ export class CloneConfigurationComponent implements OnInit {
     }
     this.configurationForm = this.formBuilder.group({
       value: ['', !this.configuration.codeId ? Validators.required : null],
+      stringValue: [null],
       countryId: [countryId, Validators.required],
       globalConfigId: [this.configId],
       codeValueId: [this.configuration.codeValueId, this.configuration.codeId ? Validators.required : null],

--- a/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.html
+++ b/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.html
@@ -19,6 +19,10 @@
               Configuration Value is <strong>required</strong>
             </mat-error>
           </mat-form-field>
+          <mat-form-field *ngIf="configuration.stringValue">
+            <mat-label>Configuration String Value</mat-label>
+            <input matInput type="string" formControlName="stringValue" />
+          </mat-form-field>
           <mat-form-field *ngIf="configuration.codeId">
             <mat-label>Configuration Value</mat-label>
             <mat-select required formControlName="codeValueId">

--- a/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.html
+++ b/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.html
@@ -12,7 +12,7 @@
             <input matInput required formControlName="name" />
           </mat-form-field>
 
-          <mat-form-field *ngIf="!configuration.codeId">
+          <mat-form-field *ngIf="!configuration.codeId && !configuration.stringValue">
             <mat-label>Configuration Value</mat-label>
             <input matInput required type="number" formControlName="value" />
             <mat-error *ngIf="configurationForm.controls.value.hasError('required')">
@@ -20,7 +20,7 @@
             </mat-error>
           </mat-form-field>
           <mat-form-field *ngIf="configuration.stringValue">
-            <mat-label>Configuration String Value</mat-label>
+            <mat-label>Configuration Value</mat-label>
             <input matInput type="string" formControlName="stringValue" />
           </mat-form-field>
           <mat-form-field *ngIf="configuration.codeId">

--- a/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.ts
@@ -50,6 +50,7 @@ export class EditConfigurationComponent implements OnInit {
   createConfigurationForm() {
     this.configurationForm = this.formBuilder.group({
       'name': [{ value: this.configuration.name, disabled: true }, Validators.required],
+      'stringValue': [this.configuration.stringValue],
       'value': [this.configuration.value, Validators.required],
       'codeValueId': [this.configuration.codeValueId, this.configuration.codeId ? Validators.required : null],
     });

--- a/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.html
+++ b/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.html
@@ -43,7 +43,14 @@
 
       <ng-container matColumnDef="value">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> Value </th>
-        <td mat-cell *matCellDef="let configuration"> {{ configuration.codeValue || configuration.value }}</td>
+        <td mat-cell *matCellDef="let configuration">
+          <ng-container *ngIf="!stringValueConfigs.includes(configuration.name); else elseTemplate">
+            {{ configuration.codeValue || configuration.value }}
+          </ng-container>
+          <ng-template #elseTemplate>
+            <span class="truncate">{{ configuration.stringValue }}</span>
+          </ng-template>
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="actions">

--- a/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.scss
+++ b/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.scss
@@ -17,3 +17,12 @@ table {
 .text-center{
   text-align: center;
 }
+
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+  display: inline-block;
+  vertical-align: bottom;
+}

--- a/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.ts
@@ -18,6 +18,9 @@ export class GlobalConfigurationsTabComponent implements OnInit {
 
   /** Configuration data. */
   configurationData: any;
+  /** Default config for string value */
+  stringValueConfigs: string[] = ["skip-ocr-credit-score-users"];
+
   /** Columns to be displayed in configurations table. */
   displayedColumns: string[] = ['name', 'country', 'ou', 'enabled', 'value', 'actions'];
   /** Data source for configurations table. */


### PR DESCRIPTION
- Accept a string value to be passed when creating a new configuration, but only for the 'skip-ocr-credit-score-users' configuration at this time.
[Ticket](https://oneacrefund.atlassian.net/browse/SER-2859) 

![Screenshot 2024-07-25 at 1 02 27 PM](https://github.com/user-attachments/assets/9b63ec1b-8a2a-4545-95b3-d7811317e478)

![Screenshot 2024-07-25 at 12 25 23 PM](https://github.com/user-attachments/assets/94b8e0d3-e4b5-49b6-bc20-a50c2be7f317)
![Screenshot 2024-07-25 at 12 25 51 PM](https://github.com/user-attachments/assets/80921a7b-d9d7-42f6-9927-86dda7ca2b76)
