### PR TITLE
SER-2854  Editing a loan product leads to loss of attached charges

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 # Release Notes
-## Version 1.3.0 - Community 1.0.0
+## Version 1.3.1 - Community 1.0.0
 
     * [SER-2854] - Removed currency control subscription on charges step during loan product update that clears charges on currency change
-    
+
 ## Version 1.3.0 - Community 1.0.0
 
     * [SER-1406] - Fix create client errors

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -74,6 +74,7 @@
     * [SER-2847] - Allow overide of OCR checks if a user has the SKIP_VERIFICATION_CLIENT permission.
     * [SER-2892] - Search fields on Client Search and Filter Bars are labeled with "Search for Client" and "Filter by Client" respectively and fix null objects in the view jobs interface.
     * [SER-2926] - Remove loan payment button from the UI
+    * [SER-2854] - Removed currency control subscription on charges step during loan product update that clears charges on currency change
 
 ## Version 1.0.0 - for use with Fineract Web App
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
+## Version 1.3.0 - Community 1.0.0
 
+    * [SER-2854] - Removed currency control subscription on charges step during loan product update that clears charges on currency change
+    
 ## Version 1.3.0 - Community 1.0.0
 
     * [SER-1406] - Fix create client errors
@@ -74,7 +77,6 @@
     * [SER-2847] - Allow overide of OCR checks if a user has the SKIP_VERIFICATION_CLIENT permission.
     * [SER-2892] - Search fields on Client Search and Filter Bars are labeled with "Search for Client" and "Filter by Client" respectively and fix null objects in the view jobs interface.
     * [SER-2926] - Remove loan payment button from the UI
-    * [SER-2854] - Removed currency control subscription on charges step during loan product update that clears charges on currency change
 
 ## Version 1.0.0 - for use with Fineract Web App
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-charges-step/loan-product-charges-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-charges-step/loan-product-charges-step.component.ts
@@ -44,7 +44,7 @@ export class LoanProductChargesStepComponent implements OnInit {
     }
     this.pristine = true;
 
-    this.currencyCode.valueChanges.subscribe(() => (this.chargesDataSource = []));
+    //this.currencyCode.valueChanges.subscribe(() => (this.chargesDataSource = []));
     this.multiDisburseLoan.valueChanges.subscribe(() => (this.chargesDataSource = []));
   }
 


### PR DESCRIPTION
## Description
Removed currency control subscription on charges step that clears charges on currency change


## Related issues and discussion
- [https://oneacrefund.atlassian.net/browse/SER-2854](https://oneacrefund.atlassian.net/browse/SER-2854)


