### PR TITLE
SER-2881 Re-enable configuration of the currency multiple from direct…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
     * [SER-2955] - Revise the global configuration pages to incorporate the new isStringValue flag field.
     * [SER-2902] - Disable loan submit button for a specific period to avoid double clicks.
     * [SER-2664] -  Show only client eligible loan products
+    * [SER-2881] -  Re-enable configuration of the currency multiple from directly on the UI during Loan Definition
 ## Version 1.3.2 - Community 1.0.0
 
     * [SER-2947] - Show or hide some menus based on user permissions.

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-organization-unit-step/loan-product-organization-unit-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-organization-unit-step/loan-product-organization-unit-step.component.html
@@ -57,6 +57,17 @@
     </div>
 
     <div fxLayout="row" class="margin-t" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="2%">
+      <mat-form-field fxFlex="50%">
+        <mat-label>Digits After Decimal</mat-label>
+        <input type="number" matInput formControlName="digitsAfterDecimal" [value]="loanProductsTemplate?.digitsAfterDecimal" required>
+      </mat-form-field>
+      <mat-form-field fxFlex="50%">
+        <mat-label>In Multiples Of</mat-label>
+        <input type="number" matInput formControlName="inMultiplesOf" [value]="loanProductsTemplate?.inMultiplesOf" required>
+      </mat-form-field>
+    </div>
+
+    <div fxLayout="row" class="margin-t" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="2%">
         <button mat-raised-button matStepperPrevious disabled>
           <fa-icon icon="arrow-left"></fa-icon>&nbsp;&nbsp;
           Previous

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-organization-unit-step/loan-product-organization-unit-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-organization-unit-step/loan-product-organization-unit-step.component.html
@@ -59,11 +59,11 @@
     <div fxLayout="row" class="margin-t" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="2%">
       <mat-form-field fxFlex="50%">
         <mat-label>Digits After Decimal</mat-label>
-        <input type="number" matInput formControlName="digitsAfterDecimal" [value]="loanProductsTemplate?.digitsAfterDecimal" required>
+        <input type="number" matInput formControlName="digitsAfterDecimal" required>
       </mat-form-field>
       <mat-form-field fxFlex="50%">
         <mat-label>In Multiples Of</mat-label>
-        <input type="number" matInput formControlName="inMultiplesOf" [value]="loanProductsTemplate?.inMultiplesOf" required>
+        <input type="number" matInput formControlName="inMultiplesOf" required>
       </mat-form-field>
     </div>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-organization-unit-step/loan-product-organization-unit-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-organization-unit-step/loan-product-organization-unit-step.component.ts
@@ -57,8 +57,8 @@ export class LoanProductOrganizationUnitStepComponent implements OnInit {
     this.loanProductOrganizationForm.patchValue({
       countryId: this.loanProductsTemplate.countryId,
       officeIds: this.loanProductsTemplate.offices?.officeId,
-      digitsAfterDecimal: 2,
-      inMultiplesOf: 1,
+      digitsAfterDecimal: this.loanProductsTemplate.currency.decimalPlaces,
+      inMultiplesOf: this.loanProductsTemplate.currency.inMultiplesOf,
       installmentAmountInMultiplesOf: 1,
     });
   }
@@ -144,7 +144,7 @@ export class LoanProductOrganizationUnitStepComponent implements OnInit {
       officeIds: [this.selectedUnits],
       currencyCode: ['', Validators.required],
       digitsAfterDecimal: ['', Validators.required],
-      inMultiplesOf: ['', Validators.required],
+      inMultiplesOf: ['', Validators.min(1)],
       installmentAmountInMultiplesOf: ['', Validators.required],
     });
     this.loanProductTemplateForm = this.formBuilder.group({


### PR DESCRIPTION
## Description
Re-enable configuration of the currency multiple from directly on the UI during Loan Definition

## Related issues and discussion
# [SER-2881](https://oneacrefund.atlassian.net/browse/SER-2881)

## Screenshots, if any
![multiples](https://github.com/user-attachments/assets/e9de3eae-303b-4589-ae38-1b62cf3490ab)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[SER-2881]: https://oneacrefund.atlassian.net/browse/SER-2881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ