### PR TITLE
chore: update release notes and version to 1.3.5; change link colors …

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,9 @@
 # Release Notes
 
 ## Version 1.3.5 - Community 1.0.0
+
     * [SER-2577] - Allow group movement regardless of loan status and office
+    * [SER-3227] - Change groups and office link color from blue to wwhite in client's detail interface
 
 ## Version 1.3.4 - Community 1.0.0
 
@@ -15,10 +17,12 @@
     * [SER-2902] - Disable loan submit button for a specific period to avoid double clicks.
     * [SER-2664] -  Show only client eligible loan products
     * [SER-2881] -  Re-enable configuration of the currency multiple from directly on the UI during Loan Definition
+
 ## Version 1.3.2 - Community 1.0.0
 
     * [SER-2947] - Show or hide some menus based on user permissions.
     * [SER-2956] - Fix regression on Display Terms&Conditions on loan product page
+
 ## Version 1.3.1 - Community 1.0.0
 
     * [SER-2854] Editing a loan product leads to loss of attached charges

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mifosx-web-app",
-  "version": "0.0.0",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mifosx-web-app",
-      "version": "0.0.0",
+      "version": "1.3.5",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -83,7 +83,9 @@
             Member Of :
 
             <span *ngIf="clientViewData.group">
-              <a [routerLink]="['/groups', clientViewData?.group?.id, 'general']">{{ clientViewData?.group?.name }}</a
+              <a [routerLink]="['/groups', clientViewData?.group?.id, 'general']" style="color: white">{{
+                clientViewData?.group?.name
+              }}</a
               >&nbsp;
             </span>
 
@@ -97,7 +99,7 @@
 
             <span *ngIf="clientViewData.officeHierarchyPath">
               Office:
-              <a [routerLink]="['/organization/offices', clientViewData?.officeId, 'general']">{{
+              <a [routerLink]="['/organization/offices', clientViewData?.officeId, 'general']" style="color: white">{{
                 clientViewData?.officeHierarchyPath
               }}</a
               >&nbsp;


### PR DESCRIPTION
## Description
Change groups and office link color from blue to wwhite in client's detail interface

## Related issues and discussion
https://oneacrefund.atlassian.net/browse/SER-3227

## Screenshots, if any
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/49d54043-a961-40a0-8cd8-4b230d3f5802">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
