### PR TITLE
feat: update link colors for group and office labels in client detail…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Version 1.3.5 - Community 1.0.0
     * [SER-2577] - Allow group movement regardless of loan status and office
+    * [SER-3227] - Change link color for group and office labels in the client detail page.
 
 ## Version 1.3.4 - Community 1.0.0
 

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -83,7 +83,9 @@
             Member Of :
 
             <span *ngIf="clientViewData.group">
-              <a [routerLink]="['/groups', clientViewData?.group?.id, 'general']">{{ clientViewData?.group?.name }}</a
+              <a [routerLink]="['/groups', clientViewData?.group?.id, 'general']" class="white-text">{{
+                clientViewData?.group?.name
+              }}</a
               >&nbsp;
             </span>
 
@@ -97,7 +99,7 @@
 
             <span *ngIf="clientViewData.officeHierarchyPath">
               Office:
-              <a [routerLink]="['/organization/offices', clientViewData?.officeId, 'general']">{{
+              <a [routerLink]="['/organization/offices', clientViewData?.officeId, 'general']" class="white-text">{{
                 clientViewData?.officeHierarchyPath
               }}</a
               >&nbsp;

--- a/src/app/clients/clients-view/clients-view.component.scss
+++ b/src/app/clients/clients-view/clients-view.component.scss
@@ -54,3 +54,7 @@
     cursor: pointer;
   }
 }
+
+.white-text {
+  color: white;
+}


### PR DESCRIPTION
## Description
Change link color for group and office labels in the client detail page.

## Related issues and discussion
https://oneacrefund.atlassian.net/browse/SER-3227

## Screenshots, if any
![image](https://github.com/user-attachments/assets/bd757341-0240-4c98-81ef-8c7846497e45)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
