### PR TITLE
Feat/SER-3203 force country support on sms campaigns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Version 1.3.4 - Community 1.0.0
+## Version 1.3.4.1 - Community 1.0.0
     * [SER-3203] - Make country support required in SMS campaign template retrieval to allow fetching country specific SMS provider details
 
 ## Version 1.3.4 - Community 1.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 # Release Notes
 
 ## Version 1.3.4 - Community 1.0.0
+    * [SER-3203] - Make country support required in SMS campaign template retrieval to allow fetching country specific SMS provider details
+
+## Version 1.3.4 - Community 1.0.0
 
     * [SER-3008] - Added ability to load organisational units (OUs) up to custom levels of the OU hierarchy config
     * [SER-2803] - Added configuration for automatically triggerring deployment with Github Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mifosx-web-app",
-  "version": "1.3.3",
+  "version": "1.3.4.1",
   "description": "MifosX Web App is the default web application built on top of the Fineract platform for the Mifos user community leveraging the popular Angular framework.",
   "keywords": [
     "mifos",

--- a/src/app/organization/organization.service.ts
+++ b/src/app/organization/organization.service.ts
@@ -368,8 +368,9 @@ export class OrganizationService {
   /**
    * @returns {Observable<any>} SMS Campaign template
    */
-  getSmsCampaignTemplate(): Observable<any> {
-    return this.http.get('/smscampaigns/template');
+  getSmsCampaignTemplate(countryId: number, countryName: string): Observable<any> {
+    const httpParams = new HttpParams().set('countryId', countryId.toString()).set('countryName', countryName);
+    return this.http.get('/smscampaigns/template', {params: httpParams});
   }
 
   /**

--- a/src/app/organization/sms-campaigns/common-resolvers/sms-campaign-template.resolver.ts
+++ b/src/app/organization/sms-campaigns/common-resolvers/sms-campaign-template.resolver.ts
@@ -24,7 +24,7 @@ export class SmsCampaignTemplateResolver implements Resolve<Object> {
    * @returns {Observable<any>}
    */
   resolve(): Observable<any> {
-    return this.organizationService.getSmsCampaignTemplate();
+    return this.organizationService.getCountries();
   }
 
 }

--- a/src/app/organization/sms-campaigns/sms-campaign-stepper/edit-sms-campaign-step/edit-sms-campaign-step.component.ts
+++ b/src/app/organization/sms-campaigns/sms-campaign-stepper/edit-sms-campaign-step/edit-sms-campaign-step.component.ts
@@ -7,6 +7,7 @@ import { ReportsService } from 'app/reports/reports.service';
 
 /** Custom Models */
 import { ReportParameter } from 'app/reports/common-models/report-parameter.model';
+import { OrganizationService } from 'app/organization/organization.service';
 
 /**
  * Edit SMS Campaign step.
@@ -49,7 +50,9 @@ export class EditSmsCampaignStepComponent implements OnInit {
    * @param {ReportsService} reportService Reports Service
    */
   constructor(private formBuilder: UntypedFormBuilder,
-              private reportService: ReportsService) {
+              private reportService: ReportsService,
+              private organizationService: OrganizationService
+            ) {
     this.createSMSCampaignDetailsForm();
   }
 
@@ -68,15 +71,20 @@ export class EditSmsCampaignStepComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.triggerTypes = this.smsCampaignTemplate.triggerTypeOptions;
-    this.smsProviders = this.smsCampaignTemplate.smsProviderOptions;
-    this.businessRules = this.smsCampaignTemplate.businessRulesOptions;
-    this.countryOptions = this.smsCampaignTemplate.countryOptions || [];
+    this.organizationService.getSmsCampaignTemplate(this.smsCampaign.country.id, this.smsCampaign.country.name).subscribe({
+      next: (response: any) => {
+        this.triggerTypes = response.triggerTypeOptions;
+        this.smsProviders = response.smsProviderOptions;
+        this.businessRules = response.businessRulesOptions;
+      }
+    });
+    
+    this.countryOptions = this.smsCampaignTemplate || [];
     this.setControlValues();
     this.getParameters();
   }
 
-  /**
+  /** 
    * Passes template parameters emitted from child to parent.
    * @param {any} $event Template Parameters
    */

--- a/src/app/organization/sms-campaigns/sms-campaign-stepper/sms-campaign-step/sms-campaign-step.component.html
+++ b/src/app/organization/sms-campaigns/sms-campaign-stepper/sms-campaign-step/sms-campaign-step.component.html
@@ -12,9 +12,15 @@
         placeholder="Select a country"
         aria-labelledby="countryOptions"
         [virtualScroll]="true"
+        (change)="onCountryChange($event)"
         required>
       </ng-select>
     </div>
+  </div>
+    
+  <div *ngIf="smsCampaignDetailsForm.controls.countryId.value">
+
+    <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column" fxLayoutAlign.gt-sm="start center">
     
     <mat-form-field fxFlex="48%">
       <mat-label>Campaign Name</mat-label>
@@ -118,7 +124,9 @@
       </mat-error>
     </mat-form-field>
 
-  </div>
+    </div>
+
+</div>
 
   <div fxLayout="row" class="margin-t" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="2%"
     *ngIf="!smsCampaignDetailsForm.controls.runReportId.value">

--- a/src/app/organization/sms-campaigns/sms-campaign-stepper/sms-campaign-step/sms-campaign-step.component.ts
+++ b/src/app/organization/sms-campaigns/sms-campaign-stepper/sms-campaign-step/sms-campaign-step.component.ts
@@ -10,6 +10,7 @@ import { ReportParameter } from 'app/reports/common-models/report-parameter.mode
 
 /** Custom Components */
 import { BusinessRuleParametersComponent } from './business-rule-parameters/business-rule-parameters.component';
+import { OrganizationService } from 'app/organization/organization.service';
 
 /**
  * SMS Campaign Step Component
@@ -53,7 +54,9 @@ export class SmsCampaignStepComponent implements OnInit {
    * @param {ReportsService} reportService Reports Service
    */
   constructor(private formBuilder: UntypedFormBuilder,
-              private reportService: ReportsService) {
+              private reportService: ReportsService,
+              private organizationService: OrganizationService
+            ) {
     this.createSMSCampaignDetailsForm();
     this.buildDependencies();
   }
@@ -62,9 +65,19 @@ export class SmsCampaignStepComponent implements OnInit {
    * Sets SMS providers and trigger types options.
    */
   ngOnInit() {
-    this.triggerTypes = this.smsCampaignTemplate.triggerTypeOptions;
-    this.smsProviders = this.smsCampaignTemplate.smsProviderOptions;
-    this.countryOptions = this.smsCampaignTemplate.countryOptions || [];
+    
+    this.countryOptions = this.smsCampaignTemplate || [];
+  }
+
+  onCountryChange(event: any) {
+
+    this.organizationService.getSmsCampaignTemplate(event.id, event.name).subscribe({
+      next: (response: any) => {
+        this.triggerTypes = response.triggerTypeOptions;
+        this.smsProviders = response.smsProviderOptions;
+        this.businessRules = response.businessRulesOptions;
+      }
+    });
   }
 
   /**
@@ -148,7 +161,6 @@ export class SmsCampaignStepComponent implements OnInit {
     });
     this.smsCampaignDetailsForm.get('triggerType').valueChanges.subscribe((value: number) => {
       this.templateParameters.emit(null);
-      this.businessRules = this.smsCampaignTemplate.businessRulesOptions;
       if (this.smsCampaignDetailsForm.controls.runReportId.value) {
         this.smsCampaignDetailsForm.get('runReportId').patchValue('');
       }


### PR DESCRIPTION
## Description
Make country support required in SMS campaign template retrieval to allow fetching country specific SMS provider details

## Changes Included in PR
- [SER-3203] - Make country support required in SMS campaign template retrieval to allow fetching country specific SMS provider details

## Screenshots, if any

### Create SMS Campaign: User is forced to select country before proceeding
- Note that the template endpoint is not called yet at this time
![image](https://github.com/user-attachments/assets/ea0166cc-d644-4cad-8b25-bb568c9ad472)

### After a country is selected
 - Note that it's when a country is selected that we are calling the template API and the rest of the form appears
![image](https://github.com/user-attachments/assets/dcea0344-3303-46f7-a14b-b33824e4be92)


.


[SER-3203]: https://oneacrefund.atlassian.net/browse/SER-3203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ