### PR TITLE
HOTFIX 1.3.4.2 - Loan Product UI Fixes for Short Name, Channels, and Client Eligibility Validation - SER-3241

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Version 1.3.4.2 - Community 1.0.0
+    * [SER-3241] - Loan Product UI Fixes - Short name, channels, and client eligibility validation
+
 ## Version 1.3.4.1 - Community 1.0.0
     * [SER-3203] - Make country support required in SMS campaign template retrieval to allow fetching country specific SMS provider details
     * [SER-3088] - Add country filter on SMS campaigns list API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mifosx-web-app",
-  "version": "1.3.4.1",
+  "version": "1.3.4.2",
   "description": "MifosX Web App is the default web application built on top of the Fineract platform for the Mifos user community leveraging the popular Angular framework.",
   "keywords": [
     "mifos",

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-apps/loan-product-apps.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-apps/loan-product-apps.component.html
@@ -2,7 +2,7 @@
     <p>Applicable Apps *</p>
     <div formArrayName="channels" class="alignText" *ngFor="let channel of channelFormArray.controls; let i = index">
       <div *ngIf="channelData[i]?.canAccessAllLoans===false">
-        <mat-checkbox fxFlex="32%" [formControlName]="i" [checked]="channelData[i].id">{{channelData[i].name}}</mat-checkbox>
+        <mat-checkbox fxFlex="32%" [formControlName]="i">{{channelData[i].name}}</mat-checkbox>
       </div>
     </div>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-apps/loan-product-apps.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-apps/loan-product-apps.component.ts
@@ -16,23 +16,19 @@ export class LoanProductAppsComponent implements OnInit {
   loanProductAppsForm: UntypedFormGroup;
   channelData: any = [];
   dataNew: any = [];
+  loanProductChannelIds: Set<number> = new Set();
 
   get channelFormArray() {
     return this.loanProductAppsForm.controls.channels as UntypedFormArray;
   }
 
   constructor(private productService: ProductsService, private formBuilder: UntypedFormBuilder, private router: Router) {
-
     this.createloanProductAppsForm();
-    this.getChannels();
   }
 
   ngOnInit(): void {
-
-    if ( this.router.url.includes('edit') ) {
-      this.loadForm(this.loanProductsTemplate);
-    }
-
+    this.loanProductChannelIds = new Set(this.loanProductsTemplate?.channels?.map((channel: any) => channel.id));
+    this.getChannels();
   }
 
   get line(): UntypedFormGroup {
@@ -58,7 +54,10 @@ export class LoanProductAppsComponent implements OnInit {
   }
 
   private addCheckboxes() {
-    this.channelData.forEach(() => this.channelFormArray.push(new UntypedFormControl(false)));
+    this.channelData.forEach(channel => {
+      const checked = this.loanProductChannelIds.has(channel.id);
+      this.channelFormArray.push(new UntypedFormControl(checked));
+    });
   }
 
   getChannels() {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.html
@@ -12,14 +12,15 @@
     <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
       <mat-label fxFlex="98%">Client Previously Defaulted</mat-label>
       <mat-form-field fxFlex="32%">
-        <input matInput formControlName="previouslyDefaultedFrom">
+        <input type="number" matInput formControlName="previouslyDefaultedFrom">
       </mat-form-field>
 
       <span>To</span>
 
       <mat-form-field fxFlex="32%">
-        <input matInput formControlName="previouslyDefaultedTo">
+        <input type="number" matInput formControlName="previouslyDefaultedTo">
       </mat-form-field>
+      <mat-error *ngIf="loanProductClientEligibilityForm.errors?.['previouslyDefaultedInvalid'] && (loanProductClientEligibilityForm.touched || loanProductClientEligibilityForm.dirty)">Both values are required</mat-error>
     </div>
     <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
       <mat-label fxFlex="98%">Minimum Credit Repaid</mat-label>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.html
@@ -36,7 +36,7 @@
       </mat-form-field>
     </div>
     <div *ngIf="loanProductsTemplate?.loanType?.id==2 || loanTypeId==2">
-      <p style="color:red">*Applicable to Group loans only</p>
+      <p class="red">*Applicable to Group loans only</p>
       <div fxLayout="row wrap" fxFlexFill fxLayoutGap="2%" fxLayout.lt-md="column">
         <mat-label fxFlex="98%">Client Group Previously Defaulted</mat-label>
           <mat-checkbox fxFlex="32%" formControlName="clientGroupPreviouslyDefaulted">Defaulted</mat-checkbox>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.scss
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.scss
@@ -17,3 +17,7 @@ table {
   .margin-t {
     margin-top: 1em;
   }
+
+.red {
+  color: red;
+}

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { UntypedFormBuilder, UntypedFormGroup, AbstractControl, ValidatorFn, ValidationErrors } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
 
@@ -53,15 +53,15 @@ export class LoanProductClientEligibilityStepComponent implements OnInit {
         previouslyNotTakenInput: null,
         previouslyTakenCredit: null,
         previouslyNotTakenCredit: null,
-        previouslyDefaultedFrom: [''],
-        previouslyDefaultedTo: [''],
+        previouslyDefaultedFrom: [null],
+        previouslyDefaultedTo: [null],
         minimumCreditRepaid: [''],
         minimumCreditRepaidType: [''],
         clientGroupPreviouslyDefaulted: null,
         clientGroupPreviouslyNotDefaulted: null,
         minimumGroupCreditRepaid: [''],
         minimumGroupCreditRepaidType: ['']
-      });
+      }, { validators: this.previouslyDefaultedValidator });
 
     }
 
@@ -74,5 +74,30 @@ export class LoanProductClientEligibilityStepComponent implements OnInit {
     }
 
     return { clientEligibility: loanProductClientEligibilityFormData };
+  }
+
+  /**
+   * Validates the previously defaulted from and to values. It ensures that both values are either provided or not provided at all.
+   * @param control AbstractControl containing the previously defaulted from and to values.
+   * @returns ValidationErrors if the values are invalid, otherwise null.
+   */
+  previouslyDefaultedValidator: ValidatorFn = (
+    control: AbstractControl,
+  ): ValidationErrors | null => {
+    const fromValueExists = this.valueExists(control.get('previouslyDefaultedFrom'));
+    const toValueExists = this.valueExists(control.get('previouslyDefaultedTo'));
+    if ((fromValueExists && !toValueExists) || (!fromValueExists && toValueExists)) {
+      return { previouslyDefaultedInvalid: true };
+    }
+    return null;
+  };
+
+  /**
+   * Checks if the control has a value.
+   * @param control AbstractControl containing the value to check.
+   * @returns True if the control has a value, otherwise false.
+   */
+  private valueExists(control: AbstractControl): boolean {
+    return control && control.value !== null && control.value !== undefined;
   }
 }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.html
@@ -12,7 +12,7 @@
 
     <mat-form-field fxFlex="48%">
       <mat-label>Short Name</mat-label>
-      <input matInput formControlName="shortName" maxlength="6" required>
+      <input matInput formControlName="shortName" maxlength="8" required>
       <mat-error>
         Short Name is <strong>required</strong>
       </mat-error>


### PR DESCRIPTION
## Description

- Increase max length that's allowed for short names to 8.
- Ensure the selected channels for a loan product are displayed correctly.
- Add validation to client eligibility's previously defaulted from and to values to ensure both values are either provided or not provided at all.

## Changes Included in PR
- [SER-3241](https://oneacrefund.atlassian.net/browse/SER-3241)



[SER-3241]: https://oneacrefund.atlassian.net/browse/SER-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ