### PR TITLE
chore: Fix UAT deployment to add dependency on build & sonarcloud jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,8 +202,8 @@ jobs:
           MATOMO_SITE_URL: "${{ vars.MATOMO_SITE_URL }}"
   UAT-k8s:
     runs-on: ubuntu-latest
-    # needs: QA-k8s
     if: github.event.ref == 'refs/heads/main' || contains(github.event.ref, 'refs/heads/hotfix/') || contains(github.event.ref, 'refs/heads/release/')
+    needs: [build, sonarcloud]
     environment:
       name: UAT
     steps:


### PR DESCRIPTION
## Description
Fixing the flow below to make sure UAT deployment waits for build and Sonarcloud jobs to complete

![image](https://github.com/user-attachments/assets/d0186286-77e5-4c41-ba04-714b19a89409)

.
