### PR TITLE
Feat/cp 3502 add country to bulk account transfers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 1.3.7 - Community 1.0.0
+
+    * [SER-3502] - Send country when submitting the account transfer bulk upload
+    
 ## Version 1.3.6 - Community 1.0.0
 
     * [SER-3363] - Implement label translation in Client related UIs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mifosx-web-app",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "MifosX Web App is the default web application built on top of the Fineract platform for the Mifos user community leveraging the popular Angular framework.",
   "keywords": [
     "mifos",

--- a/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.ts
+++ b/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.ts
@@ -217,7 +217,7 @@ export class ViewBulkImportComponent implements OnInit {
       }
     }
     let countryId = null;
-    if (this.bulkImport.name == 'Loan Repayments') {
+    if (this.bulkImport.name == 'Loan Repayments' || this.bulkImport.name == 'Account Transfer Transaction') {
       countryId = this.bulkImportForm.get('countryId').value;
       if (!countryId) {
         return this.alertService.alert({


### PR DESCRIPTION
## Description

Send the country when submitting the bulk account transfer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Country selection is now required when uploading "Account Transfer Transaction" bulk imports, in addition to "Loan Repayments". Users will be prompted to select a country if not already chosen.
- **Documentation**
  - Release notes updated to reflect the new country selection requirement for account transfer bulk uploads.
- **Chores**
  - Application version updated to 1.3.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->