### PR TITLE
Feature/CP-3564 - Translate shown substatuses by language

### DIFF
--- a/src/app/loans/loans-view/general-tab/general-tab.component.html
+++ b/src/app/loans/loans-view/general-tab/general-tab.component.html
@@ -7,10 +7,6 @@
       <p>
         {{ 'labels.inputs.Maturity Date' | translate }} :{{ getLatestDueDate() | dateFormat }}
       </p>
-
-      <p>{{ 'labels.heading.Status' | translate }} :{{ loanDetails?.status?.value }}</p>
-
-      <p *ngIf="loanDetails?.subStatus">{{ 'labels.heading.Sub Status' | translate }} :{{ loanDetails?.subStatus?.value }}</p>
     </div>
   </ng-container>
 

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -39,7 +39,7 @@
                   {{ 'labels.heading.Status' | translate }} : {{ ('labels.status.' + loanDetailsData?.status?.value) | translate }}
                 </span>
                 <span *ngIf="loanDetailsData.subStatus">
-                  {{ 'labels.heading.Sub Status' | translate }} : {{ ('labels.subStatus.' + loanDetailsData?.subStatus?.value) | translate }}
+                  - {{ ('labels.subStatus.' + loanDetailsData?.subStatus?.value) | translate }}
                 </span>
               </h3>
             </div>

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -35,6 +35,12 @@
                 <span *ngIf="loanDetailsData.group">
                   {{ 'labels.inputs.Group Name' | translate }} : {{ loanDetailsData.group.name }}
                 </span>
+                <span *ngIf="loanDetailsData.status">
+                  {{ 'labels.heading.Status' | translate }} : {{ ('labels.status.' + loanDetailsData?.status?.value) | translate }}
+                </span>
+                <span *ngIf="loanDetailsData.subStatus">
+                  {{ 'labels.heading.Sub Status' | translate }} : {{ ('labels.subStatus.' + loanDetailsData?.subStatus?.value) | translate }}
+                </span>
               </h3>
             </div>
 

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3476,6 +3476,14 @@
       "Dashboard": "Dashboard",
       "Home": "Home",
       "Login": "Login"
+    },
+    "subStatus": {
+      "Foreclosed": "Foreclosed",
+      "AwaitingCreditScore": "Awaiting Credit Score",
+      "FailedCreditScoreCheck": "Failed Credit Score Check",
+      "SANCTIONED": "Sanctioned",
+      "BLACKLISTED": "Blacklisted",
+      "Invalid": "Invalid"
     }
   },
   "languages": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3455,6 +3455,14 @@
       "Dashboard": "Tableau de bord",
       "Home": "Maison",
       "Login": "Se connecter"
+    },
+    "subStatus": {
+      "Foreclosed": "Saisi",
+      "AwaitingCreditScore": "En attente du score de crédit",
+      "FailedCreditScoreCheck": "Échec de la vérification du score de crédit",
+      "SANCTIONED": "Sanctionné",
+      "BLACKLISTED": "Liste noire",
+      "Invalid": "Invalide"
     }
   },
   "languages": {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Loan status and sub-status are now displayed in the loan information header for improved visibility.
- **Localization**
  - Added new translation keys for loan sub-statuses in both English and French to support multilingual display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1296" alt="image" src="https://github.com/user-attachments/assets/6fa34a43-f678-4259-8fc5-d78e486de7a7" />
<img width="1296" alt="image" src="https://github.com/user-attachments/assets/c2aaa233-576b-4cbf-b7ae-b7dc5701175a" />
<img width="1296" alt="image" src="https://github.com/user-attachments/assets/a059ccd9-bdce-459b-b6d5-aa5b9cc3395d" />

