### PR TITLE
Cp 3722 hide taken input on client eligibility on loan product

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Version 1.4.0 - Community 1.0.0
+
+    * Loans & Payments
+        * [CP-3722] - Hide previously taken input from loan product client eligibility 
+
 ## Version 1.3.9.1 - Community 1.0.0
 
     * [CP-3734] - Show OU Path for client, groups and offices

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-client-eligibility-step/loan-product-client-eligibility-step.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="loanProductClientEligibilityForm">
-  <div fxLayout="row wrap" fxFlexFill fxLayoutGap="2%" fxLayout.lt-md="column">
+  <!-- div fxLayout="row wrap" fxFlexFill fxLayoutGap="2%" fxLayout.lt-md="column">
     <mat-label fxFlex="98%">{{ 'labels.oaf.Previously taken input' | translate }}</mat-label>
     <mat-checkbox fxFlex="32%" formControlName="previouslyTakenInput">{{
       'labels.oaf.Taken' | translate
@@ -7,7 +7,7 @@
     <mat-checkbox fxFlex="32%" formControlName="previouslyNotTakenInput">{{
       'labels.oaf.Not Taken' | translate
     }}</mat-checkbox>
-  </div>
+  </div -->
   <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
     <mat-label fxFlex="98%">{{ 'labels.oaf.Previously taken credit' | translate }}</mat-label>
     <mat-checkbox fxFlex="32%" formControlName="previouslyTakenCredit">{{

--- a/src/app/products/loan-products/shared/client-eligbility/client-eligbility.component.html
+++ b/src/app/products/loan-products/shared/client-eligbility/client-eligbility.component.html
@@ -2,7 +2,7 @@
 
   <mat-divider fxFlexFill></mat-divider>
 
-  <div fxFlexFill>
+  <!-- div fxFlexFill>
     <span fxFlex="40%">{{ 'labels.oaf.Previously taken input' | translate }}</span>
     <span fxFlex="60%">{{ loanProduct.clientEligibility?.previouslyTakenInput }}</span>
   </div>
@@ -10,7 +10,7 @@
   <div fxFlexFill>
     <span fxFlex="40%">{{ 'labels.oaf.Previously not taken input' | translate }}</span>
     <span fxFlex="60%">{{ loanProduct.clientEligibility?.previouslyNotTakenInput }}</span>
-  </div>
+  </div -->
 
   <div fxFlexFill>
     <span fxFlex="40%">{{ 'labels.oaf.Previously taken credit' | translate }}</span>


### PR DESCRIPTION
## Description
- Hide taken input on client eligibility on loan product

## Changes Included in PR
- [CP-3722 - (https://oneacrefund.atlassian.net/browse/CP-3722)]

## PR Checklist
- [ ] Xray tests created
- [ ] PM tested and approved
- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`

FROM
<img width="1298" height="469" alt="from" src="https://github.com/user-attachments/assets/2c36bce3-0f7a-41ef-a846-05047127fccc" />


TO
<img width="1298" height="469" alt="to" src="https://github.com/user-attachments/assets/a8280ea9-ce99-4b48-be22-a326aaf082d0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed display of "Previously taken input" options and values from loan product client eligibility forms and views.

* **Documentation**
  * Added a new release note entry for version 1.4.0 - Community 1.0.0, detailing the update related to hiding previously taken input in loan product client eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->