### PR TITLE
CP-3785 - Offices not loading on transfer client

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,9 @@
     * Maker Checker
         * [CP-3723] - Improve user experience for the maker
 
+    * Clients
+        * [CP-3810] - Client transfer offices dorpdown fetch lowest OUs. Search clients also sends countryId query param to filter country clients
+
 ## Version 1.3.9.1 - Community 1.0.0
 
     * Organization Units

--- a/src/app/accounting/common-resolvers/lowest-offices.resolver.ts
+++ b/src/app/accounting/common-resolvers/lowest-offices.resolver.ts
@@ -1,13 +1,11 @@
 /** Angular Imports */
 import { Injectable } from '@angular/core';
-import { Resolve } from '@angular/router';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
 
 /** rxjs Imports */
 import { Observable } from 'rxjs';
 
 /** Custom Services */
-import { AccountingService } from '../accounting.service';
-import { GetOffices } from 'app/tasks/common-resolvers/getOffices.resolver';
 import { OrganizationService } from 'app/organization/organization.service';
 import { HttpParams } from '@angular/common/http';
 
@@ -24,10 +22,29 @@ export class LowestOfficesResolver implements Resolve<Object> {
 
   /**
    * Returns the offices data.
+   * @param {ActivatedRouteSnapshot} route Route Snapshot
    * @returns {Observable<any>}
    */
-  resolve(): Observable<any> {
-    let httpParams = new HttpParams().set('retrieveOnlyLowestLevelOUs', 'true').set('includeOfficeHierarchyPath', 'true');
+  resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    let httpParams = new HttpParams()
+      .set('retrieveOnlyLowestLevelOUs', 'true')
+      .set('includeOfficeHierarchyPath', 'true');
+
+    // Try to get countryId from route params or query params
+    let countryId = route.queryParamMap.get('countryId') || route.paramMap.get('countryId');
+
+    // If not present, default to sessionStorage value
+    if (!countryId) {
+      const selectedCountry = sessionStorage.getItem("selectedCountry");
+      if (selectedCountry) {
+        countryId = JSON.parse(selectedCountry)?.id;
+      }
+    }
+
+    if (countryId) {
+      httpParams = httpParams.set('countryId', countryId);
+    }
+
     return this.organizationService.searchOffices(httpParams);
   }
 

--- a/src/app/accounting/common-resolvers/lowest-offices.resolver.ts
+++ b/src/app/accounting/common-resolvers/lowest-offices.resolver.ts
@@ -8,17 +8,19 @@ import { Observable } from 'rxjs';
 /** Custom Services */
 import { OrganizationService } from 'app/organization/organization.service';
 import { HttpParams } from '@angular/common/http';
+import { CountryContextService } from 'app/shared/services/country-context.service';
 
 /**
  * Lowest Offices data resolver.
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class LowestOfficesResolver implements Resolve<Object> {
-
-  /**
-   * @param {OrganizationService} organizationService Organization service.
-   */
-  constructor(private organizationService: OrganizationService) {}
+  constructor(
+    private organizationService: OrganizationService,
+    private countryContext: CountryContextService
+  ) {}
 
   /**
    * Returns the offices data.
@@ -30,16 +32,7 @@ export class LowestOfficesResolver implements Resolve<Object> {
       .set('retrieveOnlyLowestLevelOUs', 'true')
       .set('includeOfficeHierarchyPath', 'true');
 
-    // Try to get countryId from route params or query params
-    let countryId = route.queryParamMap.get('countryId') || route.paramMap.get('countryId');
-
-    // If not present, default to sessionStorage value
-    if (!countryId) {
-      const selectedCountry = sessionStorage.getItem("selectedCountry");
-      if (selectedCountry) {
-        countryId = JSON.parse(selectedCountry)?.id;
-      }
-    }
+    const countryId = this.countryContext.getCountryId(route);
 
     if (countryId) {
       httpParams = httpParams.set('countryId', countryId);
@@ -47,5 +40,4 @@ export class LowestOfficesResolver implements Resolve<Object> {
 
     return this.organizationService.searchOffices(httpParams);
   }
-
 }

--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -213,7 +213,7 @@ const routes: Routes = [
               },
             },
             {
-              path: 'actions/:name',
+              path: 'actions/:name/:countryId',
               data: { title: extract('labels.text.Client Actions'), routeParamBreadcrumb: 'name' },
               component: ClientActionsComponent,
               resolve: {

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -13,7 +13,7 @@
           <button
             class="client-image-button"
             mat-raised-button
-            (click)="doAction('Upload Image')"
+            (click)="doAction('Upload Image', null)"
             matTooltip="{{ 'tooltips.Upload Image' | translate }}"
             *mifosxHasPermission="'CREATE_CLIENTIMAGE'"
           >
@@ -22,7 +22,7 @@
           <button
             class="client-image-button"
             mat-raised-button
-            (click)="doAction('Capture Image')"
+            (click)="doAction('Capture Image', null)"
             matTooltip="{{ 'tooltips.Capture Image' | translate }}"
             *mifosxHasPermission="'CREATE_CLIENTIMAGE'"
           >
@@ -31,7 +31,7 @@
           <button
             class="client-image-button"
             mat-raised-button
-            (click)="doAction('Delete Image')"
+            (click)="doAction('Delete Image', null)"
             matTooltip="{{ 'tooltips.Delete Image' | translate }}"
             *mifosxHasPermission="'DELETE_CLIENTIMAGE'"
           >
@@ -39,7 +39,7 @@
           </button>
           <br />
         </div>
-        <p (click)="doAction('View Signature')" class="signature">{{ 'labels.inputs.View Signature' | translate }}</p>
+        <p (click)="doAction('View Signature', null)" class="signature">{{ 'labels.inputs.View Signature' | translate }}</p>
       </div>
 
       <div class="mat-typography client-card-title">
@@ -170,91 +170,91 @@
         <i class="fa fa-tasks"></i>{{ 'labels.buttons.Actions' | translate }}
       </button>
       <mat-menu #Actions="matMenu">
-        <button mat-menu-item (click)="doAction('Close')" *mifosxHasPermission="'CLOSE_CLIENT'">
+        <button mat-menu-item (click)="doAction('Close', null)" *mifosxHasPermission="'CLOSE_CLIENT'">
           {{ 'labels.buttons.Close' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Transfer Client')" *mifosxHasPermission="'PROPOSETRANSFER_CLIENT'">
+        <button mat-menu-item (click)="doAction('Transfer Client', clientViewData.countryId)" *mifosxHasPermission="'PROPOSETRANSFER_CLIENT'">
           {{ 'labels.buttons.Transfer Client' | translate }}
         </button>
         <span *ngIf="clientViewData.status.value === 'Pending'"
-          ><button mat-menu-item (click)="doAction('Activate')" *mifosxHasPermission="'ACTIVATE_CLIENT'">
+          ><button mat-menu-item (click)="doAction('Activate', null)" *mifosxHasPermission="'ACTIVATE_CLIENT'">
             {{ 'labels.buttons.Activate' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Pending'"
-          ><button mat-menu-item (click)="doAction('Withdraw')">
+          ><button mat-menu-item (click)="doAction('Withdraw', null)">
             {{ 'labels.buttons.Withdraw' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Pending'"
-          ><button mat-menu-item (click)="doAction('Reject')">{{ 'labels.buttons.Reject' | translate }}</button></span
+          ><button mat-menu-item (click)="doAction('Reject', null)">{{ 'labels.buttons.Reject' | translate }}</button></span
         >
         <span *ngIf="clientViewData.status.value === 'Pending'"
-          ><button mat-menu-item *mifosxHasPermission="'DELETE_CLIENT'" (click)="doAction('Delete')">
+          ><button mat-menu-item *mifosxHasPermission="'DELETE_CLIENT'" (click)="doAction('Delete', null)">
             {{ 'labels.buttons.Delete' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Closed'"
-          ><button mat-menu-item (click)="doAction('Reactivate')" *mifosxHasPermission="'REACTIVATE_CLIENT'">
+          ><button mat-menu-item (click)="doAction('Reactivate', null)" *mifosxHasPermission="'REACTIVATE_CLIENT'">
             {{ 'labels.buttons.Reactivate' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Rejected'"
-          ><button mat-menu-item (click)="doAction('Undo Rejection')">
+          ><button mat-menu-item (click)="doAction('Undo Rejection', null)">
             {{ 'labels.buttons.Undo Rejection' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Transfer in progress'"
-          ><button mat-menu-item (click)="doAction('Undo Transfer')">
+          ><button mat-menu-item (click)="doAction('Undo Transfer', null)">
             {{ 'labels.buttons.Undo Transfer' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Transfer in progress'"
-          ><button mat-menu-item (click)="doAction('Accept Transfer')">
+          ><button mat-menu-item (click)="doAction('Accept Transfer', null)">
             {{ 'labels.buttons.Accept Transfer' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Transfer in progress'"
-          ><button mat-menu-item (click)="doAction('Reject Transfer')">
+          ><button mat-menu-item (click)="doAction('Reject Transfer', null)">
             {{ 'labels.buttons.Reject transfer' | translate }}
           </button></span
         >
       </mat-menu>
 
       <span *ngIf="!clientViewData.staffId">
-        <button mat-raised-button (click)="doAction('Assign Staff')">
+        <button mat-raised-button (click)="doAction('Assign Staff', null)">
           <i class="fa fa-user"></i>{{ 'labels.buttons.Assign Staff' | translate }}
         </button>
       </span>
       <span *ngIf="clientViewData.staffId">
-        <button mat-raised-button *mifosxHasPermission="'UNASSIGNSTAFF_CLIENT'" (click)="doAction('Unassign Staff')">
+        <button mat-raised-button *mifosxHasPermission="'UNASSIGNSTAFF_CLIENT'" (click)="doAction('Unassign Staff', null)">
           <i class="fa fa-user"></i>{{ 'labels.buttons.Unassign Staff' | translate }}
         </button>
       </span>
 
       <button mat-raised-button [matMenuTriggerFor]="More">More</button>
       <mat-menu #More="matMenu">
-        <button mat-menu-item (click)="doAction('Add Charge')" *mifosxHasPermission="'CREATE_CLIENTCHARGE'">
+        <button mat-menu-item (click)="doAction('Add Charge', null)" *mifosxHasPermission="'CREATE_CLIENTCHARGE'">
           {{ 'labels.buttons.Add Charge' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Survey')">{{ 'labels.buttons.Survey' | translate }}</button>
+        <button mat-menu-item (click)="doAction('Survey', null)">{{ 'labels.buttons.Survey' | translate }}</button>
         <button
           mat-menu-item
-          (click)="doAction('Update Default Savings')"
+          (click)="doAction('Update Default Savings', null)"
           *mifosxHasPermission="'UPDATESAVINGSACCOUNT_CLIENT'"
         >
           {{ 'labels.buttons.Update Default Savings' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Upload Signature')" *mifosxHasPermission="'CREATE_CLIENTIMAGE'">
+        <button mat-menu-item (click)="doAction('Upload Signature', null)" *mifosxHasPermission="'CREATE_CLIENTIMAGE'">
           {{ 'labels.buttons.Upload Signature' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Delete Signature')" *mifosxHasPermission="'DELETE_CLIENTIMAGE'">
+        <button mat-menu-item (click)="doAction('Delete Signature', null)" *mifosxHasPermission="'DELETE_CLIENTIMAGE'">
           {{ 'labels.buttons.Delete Signature' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Client Screen Reports')">Client Screen Reports</button>
+        <button mat-menu-item (click)="doAction('Client Screen Reports', null)">Client Screen Reports</button>
         <button
           mat-menu-item
-          (click)="doAction('Create Standing Instructions')"
+          (click)="doAction('Create Standing Instructions', null)"
           *mifosxHasPermission="'READ_STANDINGINSTRUCTION'"
         >
           {{ 'labels.buttons.Create Standing Instructions' | translate }}
@@ -262,13 +262,13 @@
         <span *ngIf="clientViewData.status.value != 'Transfer on hold'">
           <button
             mat-menu-item
-            (click)="doAction('View Standing Instructions')"
+            (click)="doAction('View Standing Instructions', null)"
             *mifosxHasPermission="'CREATE_STANDINGINSTRUCTION'"
           >
             {{ 'labels.buttons.View Standing Instructions' | translate }}
           </button>
         </span>
-        <button mat-menu-item (click)="doAction('Create Self Service User')">
+        <button mat-menu-item (click)="doAction('Create Self Service User', null)">
           {{ 'labels.buttons.Create Self Service User' | translate }}
         </button>
       </mat-menu>

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -13,7 +13,7 @@
           <button
             class="client-image-button"
             mat-raised-button
-            (click)="doAction('Upload Image', null)"
+            (click)="doAction('Upload Image', clientViewData.countryId)"
             matTooltip="{{ 'tooltips.Upload Image' | translate }}"
             *mifosxHasPermission="'CREATE_CLIENTIMAGE'"
           >
@@ -22,7 +22,7 @@
           <button
             class="client-image-button"
             mat-raised-button
-            (click)="doAction('Capture Image', null)"
+            (click)="doAction('Capture Image', clientViewData.countryId)"
             matTooltip="{{ 'tooltips.Capture Image' | translate }}"
             *mifosxHasPermission="'CREATE_CLIENTIMAGE'"
           >
@@ -31,7 +31,7 @@
           <button
             class="client-image-button"
             mat-raised-button
-            (click)="doAction('Delete Image', null)"
+            (click)="doAction('Delete Image', clientViewData.countryId)"
             matTooltip="{{ 'tooltips.Delete Image' | translate }}"
             *mifosxHasPermission="'DELETE_CLIENTIMAGE'"
           >
@@ -39,7 +39,7 @@
           </button>
           <br />
         </div>
-        <p (click)="doAction('View Signature', null)" class="signature">{{ 'labels.inputs.View Signature' | translate }}</p>
+        <p (click)="doAction('View Signature', clientViewData.countryId)" class="signature">{{ 'labels.inputs.View Signature' | translate }}</p>
       </div>
 
       <div class="mat-typography client-card-title">
@@ -170,91 +170,91 @@
         <i class="fa fa-tasks"></i>{{ 'labels.buttons.Actions' | translate }}
       </button>
       <mat-menu #Actions="matMenu">
-        <button mat-menu-item (click)="doAction('Close', null)" *mifosxHasPermission="'CLOSE_CLIENT'">
+        <button mat-menu-item (click)="doAction('Close', clientViewData.countryId)" *mifosxHasPermission="'CLOSE_CLIENT'">
           {{ 'labels.buttons.Close' | translate }}
         </button>
         <button mat-menu-item (click)="doAction('Transfer Client', clientViewData.countryId)" *mifosxHasPermission="'PROPOSETRANSFER_CLIENT'">
           {{ 'labels.buttons.Transfer Client' | translate }}
         </button>
         <span *ngIf="clientViewData.status.value === 'Pending'"
-          ><button mat-menu-item (click)="doAction('Activate', null)" *mifosxHasPermission="'ACTIVATE_CLIENT'">
+          ><button mat-menu-item (click)="doAction('Activate', clientViewData.countryId)" *mifosxHasPermission="'ACTIVATE_CLIENT'">
             {{ 'labels.buttons.Activate' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Pending'"
-          ><button mat-menu-item (click)="doAction('Withdraw', null)">
+          ><button mat-menu-item (click)="doAction('Withdraw', clientViewData.countryId)">
             {{ 'labels.buttons.Withdraw' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Pending'"
-          ><button mat-menu-item (click)="doAction('Reject', null)">{{ 'labels.buttons.Reject' | translate }}</button></span
+          ><button mat-menu-item (click)="doAction('Reject', clientViewData.countryId)">{{ 'labels.buttons.Reject' | translate }}</button></span
         >
         <span *ngIf="clientViewData.status.value === 'Pending'"
-          ><button mat-menu-item *mifosxHasPermission="'DELETE_CLIENT'" (click)="doAction('Delete', null)">
+          ><button mat-menu-item *mifosxHasPermission="'DELETE_CLIENT'" (click)="doAction('Delete', clientViewData.countryId)">
             {{ 'labels.buttons.Delete' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Closed'"
-          ><button mat-menu-item (click)="doAction('Reactivate', null)" *mifosxHasPermission="'REACTIVATE_CLIENT'">
+          ><button mat-menu-item (click)="doAction('Reactivate', clientViewData.countryId)" *mifosxHasPermission="'REACTIVATE_CLIENT'">
             {{ 'labels.buttons.Reactivate' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Rejected'"
-          ><button mat-menu-item (click)="doAction('Undo Rejection', null)">
+          ><button mat-menu-item (click)="doAction('Undo Rejection', clientViewData.countryId)">
             {{ 'labels.buttons.Undo Rejection' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Transfer in progress'"
-          ><button mat-menu-item (click)="doAction('Undo Transfer', null)">
+          ><button mat-menu-item (click)="doAction('Undo Transfer', clientViewData.countryId)">
             {{ 'labels.buttons.Undo Transfer' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Transfer in progress'"
-          ><button mat-menu-item (click)="doAction('Accept Transfer', null)">
+          ><button mat-menu-item (click)="doAction('Accept Transfer', clientViewData.countryId)">
             {{ 'labels.buttons.Accept Transfer' | translate }}
           </button></span
         >
         <span *ngIf="clientViewData.status.value === 'Transfer in progress'"
-          ><button mat-menu-item (click)="doAction('Reject Transfer', null)">
+          ><button mat-menu-item (click)="doAction('Reject Transfer', clientViewData.countryId)">
             {{ 'labels.buttons.Reject transfer' | translate }}
           </button></span
         >
       </mat-menu>
 
       <span *ngIf="!clientViewData.staffId">
-        <button mat-raised-button (click)="doAction('Assign Staff', null)">
+        <button mat-raised-button (click)="doAction('Assign Staff', clientViewData.countryId)">
           <i class="fa fa-user"></i>{{ 'labels.buttons.Assign Staff' | translate }}
         </button>
       </span>
       <span *ngIf="clientViewData.staffId">
-        <button mat-raised-button *mifosxHasPermission="'UNASSIGNSTAFF_CLIENT'" (click)="doAction('Unassign Staff', null)">
+        <button mat-raised-button *mifosxHasPermission="'UNASSIGNSTAFF_CLIENT'" (click)="doAction('Unassign Staff', clientViewData.countryId)">
           <i class="fa fa-user"></i>{{ 'labels.buttons.Unassign Staff' | translate }}
         </button>
       </span>
 
       <button mat-raised-button [matMenuTriggerFor]="More">More</button>
       <mat-menu #More="matMenu">
-        <button mat-menu-item (click)="doAction('Add Charge', null)" *mifosxHasPermission="'CREATE_CLIENTCHARGE'">
+        <button mat-menu-item (click)="doAction('Add Charge', clientViewData.countryId)" *mifosxHasPermission="'CREATE_CLIENTCHARGE'">
           {{ 'labels.buttons.Add Charge' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Survey', null)">{{ 'labels.buttons.Survey' | translate }}</button>
+        <button mat-menu-item (click)="doAction('Survey', clientViewData.countryId)">{{ 'labels.buttons.Survey' | translate }}</button>
         <button
           mat-menu-item
-          (click)="doAction('Update Default Savings', null)"
+          (click)="doAction('Update Default Savings', clientViewData.countryId)"
           *mifosxHasPermission="'UPDATESAVINGSACCOUNT_CLIENT'"
         >
           {{ 'labels.buttons.Update Default Savings' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Upload Signature', null)" *mifosxHasPermission="'CREATE_CLIENTIMAGE'">
+        <button mat-menu-item (click)="doAction('Upload Signature', clientViewData.countryId)" *mifosxHasPermission="'CREATE_CLIENTIMAGE'">
           {{ 'labels.buttons.Upload Signature' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Delete Signature', null)" *mifosxHasPermission="'DELETE_CLIENTIMAGE'">
+        <button mat-menu-item (click)="doAction('Delete Signature', clientViewData.countryId)" *mifosxHasPermission="'DELETE_CLIENTIMAGE'">
           {{ 'labels.buttons.Delete Signature' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Client Screen Reports', null)">Client Screen Reports</button>
+        <button mat-menu-item (click)="doAction('Client Screen Reports', clientViewData.countryId)">Client Screen Reports</button>
         <button
           mat-menu-item
-          (click)="doAction('Create Standing Instructions', null)"
+          (click)="doAction('Create Standing Instructions', clientViewData.countryId)"
           *mifosxHasPermission="'READ_STANDINGINSTRUCTION'"
         >
           {{ 'labels.buttons.Create Standing Instructions' | translate }}
@@ -262,13 +262,13 @@
         <span *ngIf="clientViewData.status.value != 'Transfer on hold'">
           <button
             mat-menu-item
-            (click)="doAction('View Standing Instructions', null)"
+            (click)="doAction('View Standing Instructions', clientViewData.countryId)"
             *mifosxHasPermission="'CREATE_STANDINGINSTRUCTION'"
           >
             {{ 'labels.buttons.View Standing Instructions' | translate }}
           </button>
         </span>
-        <button mat-menu-item (click)="doAction('Create Self Service User', null)">
+        <button mat-menu-item (click)="doAction('Create Self Service User', clientViewData.countryId)">
           {{ 'labels.buttons.Create Self Service User' | translate }}
         </button>
       </mat-menu>

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -108,7 +108,7 @@ export class ClientsViewComponent implements OnInit {
    * Performs action button/option action.
    * @param {string} name action name.
    */
-  doAction(name: string) {
+  doAction(name: string, countryId: string | null) {
     switch (name) {
       case 'Assign Staff':
       case 'Close':
@@ -126,7 +126,7 @@ export class ClientsViewComponent implements OnInit {
       case 'Add Charge':
       case 'Create Self Service User':
       case 'Client Screen Reports':
-        this.router.navigate([`actions/${name}`], { relativeTo: this.route });
+        this.router.navigate([`actions/${name}/${countryId}`], { relativeTo: this.route });
         break;
       case 'Unassign Staff':
         this.unassignStaff();

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -1,5 +1,5 @@
 /** Angular Imports */
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatDialog } from '@angular/material/dialog';
@@ -27,7 +27,7 @@ import { APP_CONSTANTS } from 'app/shared/constants/app.constants';
   templateUrl: './clients-view.component.html',
   styleUrls: ['./clients-view.component.scss']
 })
-export class ClientsViewComponent implements OnInit {
+export class ClientsViewComponent implements OnInit, OnDestroy {
 
   clientViewData: any;
   clientDatatables: any;

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -390,8 +390,8 @@ export class ClientsService {
   /**
    * @returns {Observable<any>} Offices data
    */
-  getOffices(): Observable<any> {
-    return this.http.get('/offices');
+  getOffices(countryId: string): Observable<any> {
+    return this.http.get('/offices?includeOfficeHierarchyPath=false&countryId=' + countryId);
   }
 
   /**

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -390,8 +390,8 @@ export class ClientsService {
   /**
    * @returns {Observable<any>} Offices data
    */
-  getOffices(countryId: string): Observable<any> {
-    return this.http.get('/offices?includeOfficeHierarchyPath=false&countryId=' + countryId);
+  getOffices(): Observable<any> {
+    return this.http.get('/offices');
   }
 
   /**

--- a/src/app/clients/common-resolvers/client-actions.resolver.ts
+++ b/src/app/clients/common-resolvers/client-actions.resolver.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 
 /** Custom Services */
 import { ClientsService } from '../clients.service';
+import { LowestOfficesResolver } from 'app/accounting/common-resolvers/lowest-offices.resolver';
 
 /**
  * Client Actions data resolver.
@@ -16,7 +17,10 @@ export class ClientActionsResolver implements Resolve<Object> {
   /**
    * @param {ClientsService} clientsService Clients service.
    */
-  constructor(private clientsService: ClientsService) {}
+  constructor(
+    private clientsService: ClientsService,
+    private lowestOfficesResolver: LowestOfficesResolver
+  ) {}
 
   /**
    * Returns the clients actions data.
@@ -40,7 +44,7 @@ export class ClientActionsResolver implements Resolve<Object> {
       case 'Withdraw':
         return this.clientsService.getClientCommandTemplate('withdraw');
       case 'Transfer Client':
-        return this.clientsService.getOffices();
+        return this.lowestOfficesResolver.resolve(route);
       case 'Add Charge':
         return this.clientsService.getClientChargeTemplate(clientId);
       case 'Client Screen Reports':

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -29,8 +29,6 @@ export class SearchService {
       countryId = JSON.parse(selectedCountry)?.id;
     }
 
-    console.log('Country ID:', countryId);
-
     let httpParams = new HttpParams()
       .set('exactMatch', 'false')
       .set('query', query)

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -23,11 +23,23 @@ export class SearchService {
    * @returns {Observable<any>} Search Results.
    */
   getSearchResults(query: string, resource: string): Observable<any> {
-    const httpParams = new HttpParams()
+    let countryId = undefined;
+    const selectedCountry = sessionStorage.getItem("selectedCountry");
+    if (selectedCountry) {
+      countryId = JSON.parse(selectedCountry)?.id;
+    }
+
+    console.log('Country ID:', countryId);
+
+    let httpParams = new HttpParams()
       .set('exactMatch', 'false')
       .set('query', query)
       .set('resource', resource)
       .set('includeOfficeHierarchyPath', 'true');
+
+    if (countryId != undefined) {
+       httpParams = httpParams.set('countryId', countryId);
+    }
     return this.http.get('/search', { params: httpParams });
   }
 }

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -5,6 +5,8 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 /** rxjs Imports */
 import { Observable } from 'rxjs';
 
+import { CountryContextService } from 'app/shared/services/country-context.service';
+
 /**
  * Search service.
  */
@@ -14,8 +16,12 @@ import { Observable } from 'rxjs';
 export class SearchService {
   /**
    * @param {HttpClient} http Http Client to send requests.
+   * @param {CountryContextService} countryContext Country context service.
    */
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private countryContext: CountryContextService
+  ) {}
 
   /**
    * @param {string} query Query String
@@ -23,11 +29,7 @@ export class SearchService {
    * @returns {Observable<any>} Search Results.
    */
   getSearchResults(query: string, resource: string): Observable<any> {
-    let countryId = undefined;
-    const selectedCountry = sessionStorage.getItem("selectedCountry");
-    if (selectedCountry) {
-      countryId = JSON.parse(selectedCountry)?.id;
-    }
+    const countryId = this.countryContext.getCountryId();
 
     let httpParams = new HttpParams()
       .set('exactMatch', 'false')
@@ -36,7 +38,7 @@ export class SearchService {
       .set('includeOfficeHierarchyPath', 'true');
 
     if (countryId != undefined) {
-       httpParams = httpParams.set('countryId', countryId);
+      httpParams = httpParams.set('countryId', countryId);
     }
     return this.http.get('/search', { params: httpParams });
   }

--- a/src/app/shared/services/country-context.service.ts
+++ b/src/app/shared/services/country-context.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { APP_CONSTANTS } from 'app/shared/constants/app.constants';
+
+@Injectable({ providedIn: 'root' })
+export class CountryContextService {
+  getCountryId(route?: ActivatedRouteSnapshot): string | undefined {
+    const fromQuery = route?.queryParamMap.get('countryId');
+    const fromParam = route?.paramMap.get('countryId');
+    let countryId = [fromQuery, fromParam].find(
+      v => v != null && v !== 'null' && v !== 'undefined'
+    ) as string | undefined;
+
+    if (!countryId) {
+      const raw = sessionStorage.getItem(APP_CONSTANTS.SESSION_STORAGE.SELECTED_COUNTRY);
+      try {
+        const parsed = raw ? JSON.parse(raw) : undefined;
+        if (parsed?.id != null) {
+          countryId = String(parsed.id);
+        }
+      } catch {
+        // ignore malformed value
+      }
+    }
+    return countryId;
+  }
+}


### PR DESCRIPTION
Get the lowest OUs only and filter by countryId to help fasten the offices fetch. Also added countryId to the search API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Client search now filters results by selected country (search requests include country context).
  - “Transfer Client” displays only lowest-level offices, filtered by country.
  - Client action navigation now includes country context to ensure country-specific actions.

- **Documentation**
  - Added CP-3810 to release notes (v1.4.0) documenting the country-aware client search and lowest-level office selection for transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->