### PR TITLE
Bug/CP-3810 - Redirecting to the client page after any action to avoid the 404 error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@
 
     * Clients
         * [CP-3810] - Client transfer offices dorpdown fetch lowest OUs. Search clients also sends countryId query param to filter country clients
+        * [CP-3844] - Fix 404 after client transfer due to route hierarchy update
 
 ## Version 1.3.9.1 - Community 1.0.0
 

--- a/src/app/account-transfers/create-standing-instructions/create-standing-instructions.component.html
+++ b/src/app/account-transfers/create-standing-instructions/create-standing-instructions.component.html
@@ -232,7 +232,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../']">Cancel</button>
+        <button type="button" mat-raised-button [routerLink]="['../../']">Cancel</button>
         <button mat-raised-button color="primary" [disabled]="!createStandingInstructionsForm.valid" *mifosxHasPermission="'CREATE_STANDINGINSTRUCTION'"
           (click)="submit()">Submit</button>
       </mat-card-actions>

--- a/src/app/clients/clients-view/client-actions/accept-client-transfer/accept-client-transfer.component.html
+++ b/src/app/clients/clients-view/client-actions/accept-client-transfer/accept-client-transfer.component.html
@@ -16,7 +16,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="primary" [disabled]="!acceptClientTransferForm.valid">

--- a/src/app/clients/clients-view/client-actions/accept-client-transfer/accept-client-transfer.component.ts
+++ b/src/app/clients/clients-view/client-actions/accept-client-transfer/accept-client-transfer.component.ts
@@ -91,7 +91,7 @@ export class AcceptClientTransferComponent implements OnInit {
     this.matomoTracker.trackEvent('clients', 'acceptClientTransfer',this.clientId);// change to track right info
 
     this.clientsService.executeClientCommand(this.clientId, "acceptTransfer", data).subscribe(() => {
-      this.router.navigate(["../../"], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 }

--- a/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.html
+++ b/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.html
@@ -31,7 +31,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="accent" [disabled]="!activateClientForm.valid">

--- a/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.ts
@@ -90,7 +90,7 @@ export class ActivateClientComponent implements OnInit {
     this.matomoTracker.trackEvent('clients', 'activate', this.clientId); // change to track right info
 
     this.clientsService.executeClientCommand(this.clientId, 'activate', data).subscribe(() => {
-      this.router.navigate(['../../'], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 }

--- a/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.html
+++ b/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.html
@@ -91,7 +91,7 @@
         </div>
 
         <mat-card-actions fxLayoutGap="5px" fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center">
-          <button type="button" mat-raised-button [routerLink]="['../../']">
+          <button type="button" mat-raised-button [routerLink]="['../../../']">
             {{ 'labels.buttons.Cancel' | translate }}
           </button>
           <button mat-raised-button color="primary" [disabled]="!clientChargeForm.valid">

--- a/src/app/clients/clients-view/client-actions/client-assign-staff/client-assign-staff.component.html
+++ b/src/app/clients/clients-view/client-actions/client-assign-staff/client-assign-staff.component.html
@@ -25,7 +25,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">  {{ 'labels.buttons.Cancel' | translate }}</button>
+        <button type="button" mat-raised-button [routerLink]="['../../../']">  {{ 'labels.buttons.Cancel' | translate }}</button>
         <button mat-raised-button color="primary" [disabled]="!clientAssignStaffForm.valid">   {{ 'labels.buttons.Confirm' | translate }}</button>
       </mat-card-actions>
 

--- a/src/app/clients/clients-view/client-actions/client-assign-staff/client-assign-staff.component.ts
+++ b/src/app/clients/clients-view/client-actions/client-assign-staff/client-assign-staff.component.ts
@@ -73,7 +73,7 @@ export class ClientAssignStaffComponent implements OnInit {
 
     this.clientsService.executeClientCommand(this.clientData.id, 'assignStaff', this.clientAssignStaffForm.value)
       .subscribe(() => {
-        this.router.navigate(['../../'], { relativeTo: this.route });
+        this.clientsService.redirectToClient(this.clientData.id);
       });
   }
 

--- a/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.html
+++ b/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.html
@@ -19,7 +19,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="primary" [disabled]="!clientScreenReportForm.valid">

--- a/src/app/clients/clients-view/client-actions/close-client/close-client.component.html
+++ b/src/app/clients/clients-view/client-actions/close-client/close-client.component.html
@@ -37,7 +37,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="warn" [disabled]="!closeClientForm.valid">

--- a/src/app/clients/clients-view/client-actions/close-client/close-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/close-client/close-client.component.ts
@@ -91,7 +91,7 @@ export class CloseClientComponent implements OnInit {
      this.matomoTracker.trackEvent('clients', 'close', this.clientId);
 
     this.clientsService.executeClientCommand(this.clientId, 'close', data).subscribe(() => {
-      this.router.navigate(['../../'], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 

--- a/src/app/clients/clients-view/client-actions/reactivate-client/reactivate-client.component.html
+++ b/src/app/clients/clients-view/client-actions/reactivate-client/reactivate-client.component.html
@@ -46,7 +46,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="accent" [disabled]="!reactivateClientForm.valid">

--- a/src/app/clients/clients-view/client-actions/reactivate-client/reactivate-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/reactivate-client/reactivate-client.component.ts
@@ -97,7 +97,7 @@ export class ReactivateClientComponent implements OnInit {
     this.matomoTracker.trackEvent('clients', 'reactivate', this.clientId);
 
     this.clientsService.executeClientCommand(this.clientId, 'reactivate', data).subscribe(() => {
-      this.router.navigate(['../../'], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 }

--- a/src/app/clients/clients-view/client-actions/reject-client-transfer/reject-client-transfer.component.html
+++ b/src/app/clients/clients-view/client-actions/reject-client-transfer/reject-client-transfer.component.html
@@ -16,7 +16,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="primary" [disabled]="!rejectClientTransferForm.valid">

--- a/src/app/clients/clients-view/client-actions/reject-client-transfer/reject-client-transfer.component.ts
+++ b/src/app/clients/clients-view/client-actions/reject-client-transfer/reject-client-transfer.component.ts
@@ -85,7 +85,7 @@ export class RejectClientTransferComponent implements OnInit {
     this.matomoTracker.trackEvent('clients', 'rejectTransfer', this.clientId);
 
     this.clientsService.executeClientCommand(this.clientId, 'rejectTransfer', data).subscribe(() => {
-      this.router.navigate(['../../'], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 

--- a/src/app/clients/clients-view/client-actions/reject-client/reject-client.component.html
+++ b/src/app/clients/clients-view/client-actions/reject-client/reject-client.component.html
@@ -37,7 +37,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="warn" [disabled]="!rejectClientForm.valid">

--- a/src/app/clients/clients-view/client-actions/reject-client/reject-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/reject-client/reject-client.component.ts
@@ -91,7 +91,7 @@ export class RejectClientComponent implements OnInit {
      this.matomoTracker.trackEvent('clients', 'reject', this.clientId);
 
     this.clientsService.executeClientCommand(this.clientId, 'reject', data).subscribe(() => {
-      this.router.navigate(['../../'], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 

--- a/src/app/clients/clients-view/client-actions/transfer-client/transfer-client.component.html
+++ b/src/app/clients/clients-view/client-actions/transfer-client/transfer-client.component.html
@@ -47,7 +47,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="primary" [disabled]="!transferClientForm.valid">

--- a/src/app/clients/clients-view/client-actions/transfer-client/transfer-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/transfer-client/transfer-client.component.ts
@@ -98,7 +98,7 @@ export class TransferClientComponent implements OnInit {
     this.matomoTracker.trackEvent('clients', 'proposeTransfer', this.clientId);
 
     this.clientsService.executeClientCommand(this.clientId, "proposeTransfer", data).subscribe(() => {
-      this.router.navigate(["../../"], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 }

--- a/src/app/clients/clients-view/client-actions/undo-client-rejection/undo-client-rejection.component.html
+++ b/src/app/clients/clients-view/client-actions/undo-client-rejection/undo-client-rejection.component.html
@@ -22,7 +22,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="accent" [disabled]="!undoClientRejectionForm.valid">

--- a/src/app/clients/clients-view/client-actions/undo-client-rejection/undo-client-rejection.component.ts
+++ b/src/app/clients/clients-view/client-actions/undo-client-rejection/undo-client-rejection.component.ts
@@ -87,7 +87,7 @@ export class UndoClientRejectionComponent implements OnInit {
     this.matomoTracker.trackEvent('clients', 'undoRejection', this.clientId);
 
     this.clientsService.executeClientCommand(this.clientId, 'undoRejection', data).subscribe(() => {
-      this.router.navigate(['../../'], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 

--- a/src/app/clients/clients-view/client-actions/undo-client-transfer/undo-client-transfer.component.html
+++ b/src/app/clients/clients-view/client-actions/undo-client-transfer/undo-client-transfer.component.html
@@ -16,7 +16,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="primary" [disabled]="!undoClientTransferForm.valid">

--- a/src/app/clients/clients-view/client-actions/undo-client-transfer/undo-client-transfer.component.ts
+++ b/src/app/clients/clients-view/client-actions/undo-client-transfer/undo-client-transfer.component.ts
@@ -89,7 +89,7 @@ export class UndoClientTransferComponent implements OnInit {
     this.matomoTracker.trackEvent('clients', 'undoClientTransfer', this.clientId);
 
     this.clientsService.executeClientCommand(this.clientId, "withdrawTransfer", data).subscribe(() => {
-      this.router.navigate(["../../"], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 }

--- a/src/app/clients/clients-view/client-actions/update-client-savings-account/update-client-savings-account.component.html
+++ b/src/app/clients/clients-view/client-actions/update-client-savings-account/update-client-savings-account.component.html
@@ -19,7 +19,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="primary" [disabled]="!clientSavingsAccountForm.valid">

--- a/src/app/clients/clients-view/client-actions/update-client-savings-account/update-client-savings-account.component.ts
+++ b/src/app/clients/clients-view/client-actions/update-client-savings-account/update-client-savings-account.component.ts
@@ -70,7 +70,7 @@ export class UpdateClientSavingsAccountComponent implements OnInit {
 
     this.clientsService.executeClientCommand(this.clientData.id, 'updateSavingsAccount', this.clientSavingsAccountForm.value)
       .subscribe(() => {
-        this.router.navigate(['../../'], { relativeTo: this.route });
+        this.clientsService.redirectToClient(this.clientData.id);
       });
   }
 

--- a/src/app/clients/clients-view/client-actions/withdraw-client/withdraw-client.component.html
+++ b/src/app/clients/clients-view/client-actions/withdraw-client/withdraw-client.component.html
@@ -37,7 +37,7 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="primary" [disabled]="!withdrawClientForm.valid">

--- a/src/app/clients/clients-view/client-actions/withdraw-client/withdraw-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/withdraw-client/withdraw-client.component.ts
@@ -91,7 +91,7 @@ export class WithdrawClientComponent implements OnInit {
     this.matomoTracker.trackEvent('clients', 'withdraw', this.clientId);
 
     this.clientsService.executeClientCommand(this.clientId, 'withdraw', data).subscribe(() => {
-      this.router.navigate(['../../'], { relativeTo: this.route });
+      this.clientsService.redirectToClient(this.clientId);
     });
   }
 

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -1,6 +1,7 @@
 /** Angular Imports */
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
+import { Router } from '@angular/router';
 
 /** rxjs Imports */
 import { Observable } from 'rxjs';
@@ -14,7 +15,7 @@ export class ClientsService {
   /**
    * @param {HttpClient} http Http Client to send requests.
    */
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private router: Router) {}
 
   getFilteredClients(
     orderBy: string,
@@ -443,5 +444,13 @@ export class ClientsService {
    */
   validateClientOTP(countryId: number, otpData: any) {
     return this.http.post(`/clients/validateMobileNumberOTP/${countryId}`, otpData);
+  }
+
+  /**
+    * Redirects to the client view page.
+    * @param clientId Client Id.
+   */
+  public redirectToClient(clientId: any) {
+    this.router.navigate(['clients', clientId, 'general'], { queryParamsHandling: 'preserve' });
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved 404 errors after client transfer by correcting navigation paths.
  - Fixed Cancel button navigation across client action screens (activate, reject, accept/reject transfer, close, withdraw, undo actions, assign staff, update savings, screen reports) to return to the correct client view.
  - Ensured successful client actions consistently redirect back to the client’s profile.

- Documentation
  - Added release note entry (CP-3844) under Version 1.4.0 - Community 1.0.0 describing the 404 fix after client transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->