### PR TITLE
fix: When preventing editsFilter active loans to only include 'ACTIVE…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Version 1.4.1 - Community 1.0.0
+    
+    * Clients
+        * [CP-3663] - Fix: Only restrict cllient edits on clients with active loans
+
 ## Version 1.4.0 - Community 1.0.0
 
     * Loans & Payments

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mifosx-web-app",
-  "version": "1.3.9",
+  "version": "1.4.1",
   "description": "MifosX Web App is the default web application built on top of the Fineract platform for the Mifos user community leveraging the popular Angular framework.",
   "keywords": [
     "mifos",

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -424,11 +424,11 @@ export class ClientsViewComponent implements OnInit, OnDestroy {
     }
 
     // If client has active loans, check loan qualification rules
-    if (countryId != null) {
-      this.checkLoanQualificationRules(countryId);
-    } else {
+    if (countryId === null) {
       // No country ID, do not allow edit
       this.isEditAllowedFlag = false;
+    } else {
+      this.checkLoanQualificationRules(countryId);
     }
   }
   isEditAllowed(): boolean {

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -363,7 +363,7 @@ export class ClientsViewComponent implements OnInit, OnDestroy {
     if (!this.loanAccounts || this.loanAccounts.length === 0) {
       return false;
     }
-    const activeLoans = this.loanAccounts.filter((loan: LoanAccount) =>
+    const activeLoans = this.loanAccounts.filter((loan: any) =>
       loan.status?.id === APP_CONSTANTS.LOAN_STATUSES.ACTIVE
     );
     return activeLoans.length > 0;

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -363,8 +363,8 @@ export class ClientsViewComponent implements OnInit, OnDestroy {
     if (!this.loanAccounts || this.loanAccounts.length === 0) {
       return false;
     }
-    const activeLoans = this.loanAccounts.filter((loan: any) =>
-      [APP_CONSTANTS.LOAN_STATUSES.ACTIVE].includes(loan.status?.id)
+    const activeLoans = this.loanAccounts.filter((loan: LoanAccount) =>
+      loan.status?.id === APP_CONSTANTS.LOAN_STATUSES.ACTIVE
     );
     return activeLoans.length > 0;
   }

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -364,7 +364,7 @@ export class ClientsViewComponent implements OnInit, OnDestroy {
       return false;
     }
     const activeLoans = this.loanAccounts.filter((loan: any) =>
-      [APP_CONSTANTS.LOAN_STATUSES.SUBMITTED_AND_PENDING_APPROVAL, APP_CONSTANTS.LOAN_STATUSES.ACTIVE, APP_CONSTANTS.LOAN_STATUSES.APPROVED].includes(loan.status?.id)
+      [APP_CONSTANTS.LOAN_STATUSES.ACTIVE].includes(loan.status?.id)
     );
     return activeLoans.length > 0;
   }


### PR DESCRIPTION
…' status

