### PR TITLE
CP-3666 Refactor Template Configuration with HTML Support Per Country

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 1.4.6 - Community 1.0.0
+    * Configurations
+        * [CP-3666] - Refactor Template Configuration with HTML Support Per Country
+
 ## Version 1.4.1 - Community 1.0.0
 
     * Clients

--- a/src/app/templates/common-resolvers/templates.resolver.ts
+++ b/src/app/templates/common-resolvers/templates.resolver.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 
 /** Custom Services */
 import { TemplatesService } from '../templates.service';
+import { SettingsService } from 'app/settings/settings.service';
 
 /**
  * Templates data resolver.
@@ -17,14 +18,14 @@ export class TemplatesResolver implements Resolve<Object> {
   /**
    * @param {TemplatesService} templatesService Templates service.
    */
-  constructor(private templatesService: TemplatesService) {}
+  constructor(private templatesService: TemplatesService, private settingService: SettingsService) {}
 
   /**
    * Returns the templates data.
    * @returns {Observable<any>}
    */
   resolve(): Observable<any> {
-    return this.templatesService.getTemplates();
+    return this.templatesService.getTemplates({ countryId: this.settingService.getSelectedCountry()?.id || undefined });
   }
 
 }

--- a/src/app/templates/create-template/create-template.component.html
+++ b/src/app/templates/create-template/create-template.component.html
@@ -9,20 +9,9 @@
         <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
 
           <mat-form-field fxFlex="48%">
-            <mat-label>{{ 'labels.oaf.Country' | translate }}</mat-label>
-            <mat-select required formControlName="countryId">
-              <mat-option *ngFor="let country of countries" [value]="country.id">
-                {{ country.name }}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="templateForm.controls.countryId.hasError('required')">{{ 'labels.commons.Country is' | translate }}<strong>{{ 'labels.commons.required' | translate }}</strong>
-            </mat-error>
-          </mat-form-field>
-
-          <mat-form-field fxFlex="48%">
             <mat-label>{{ 'labels.inputs.Entity' | translate }}</mat-label>
             <mat-select required formControlName="entity">
-              <mat-option *ngFor="let entity of createTemplateData.entities" [value]="entity.id">
+              <mat-option *ngFor="let entity of createTemplateData.entities" [value]="entity.code">
                 {{ entity.name }}
               </mat-option>
             </mat-select>
@@ -33,7 +22,7 @@
           <mat-form-field fxFlex="48%">
             <mat-label>{{ 'labels.inputs.Type' | translate }}</mat-label>
             <mat-select required formControlName="type">
-              <mat-option *ngFor="let type of createTemplateData.types" [value]="type.id">
+              <mat-option *ngFor="let type of templateTypes" [value]="type.code">
                 {{ type.name }}
               </mat-option>
             </mat-select>
@@ -41,7 +30,7 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field fxFlex="48%">
+          <mat-form-field fxFlex="98%">
             <mat-label>{{ 'labels.inputs.Name' | translate }}</mat-label>
             <input matInput required formControlName="name">
             <mat-error *ngIf="templateForm.controls.name.hasError('required')">{{ 'labels.oaf.Name is' | translate }}<strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -93,7 +82,7 @@
 
       <mat-accordion>
 
-        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 0">
+        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 'CLIENT'">
 
           <mat-expansion-panel-header>
             <mat-panel-title>{{ 'labels.inputs.Client Parameters' | translate }}</mat-panel-title>
@@ -108,7 +97,7 @@
 
         </mat-expansion-panel>
 
-        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 1">
+        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 'LOAN'">
 
           <mat-expansion-panel-header>
             <mat-panel-title>{{ 'labels.inputs.Loan Parameters' | translate }}</mat-panel-title>
@@ -123,7 +112,7 @@
 
         </mat-expansion-panel>
 
-        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 1">
+        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 'LOAN'">
 
           <mat-expansion-panel-header>
             <mat-panel-title>{{ 'labels.inputs.Repayment Schedule Parameters' | translate }}</mat-panel-title>

--- a/src/app/templates/create-template/create-template.component.ts
+++ b/src/app/templates/create-template/create-template.component.ts
@@ -90,6 +90,7 @@ export class CreateTemplateComponent implements OnInit {
   buildDependencies() {
     const tenantIdentifier = 'default'; // update once global settings are setup.
     this.templateForm.get('entity').valueChanges.subscribe((value: any) => {
+      this.templateForm.get('type').patchValue(null);
       this.templateTypes = this.createTemplateData.entities.filter((entity: any) => entity.code === value)[0]?.templateTypes;
       if (value === 'CLIENT') { // client
         this.mappers.splice(0, 1, {

--- a/src/app/templates/create-template/create-template.component.ts
+++ b/src/app/templates/create-template/create-template.component.ts
@@ -11,6 +11,7 @@ import { clientParameterLabels, loanParameterLabels, repaymentParameterLabels } 
 
 /** Custom Services */
 import { TemplatesService } from '../templates.service';
+import { SettingsService } from 'app/settings/settings.service';
 
 /**
  * Create Template Component.
@@ -47,6 +48,9 @@ export class CreateTemplateComponent implements OnInit {
   /** Repayment Parameter Labels */
   repaymentParameterLabels: string[] = repaymentParameterLabels;
 
+  /** Template entity types */
+  templateTypes: any[] = [];
+
   /**
    * Retrieves the template data from `resolve`.
    * @param {FormBuilder} formBuilder Form Builder.
@@ -57,10 +61,10 @@ export class CreateTemplateComponent implements OnInit {
   constructor(private formBuilder: UntypedFormBuilder,
               private route: ActivatedRoute,
               private router: Router,
+              private settingsService: SettingsService,
               private templateService: TemplatesService) {
     this.route.data.subscribe((data: { createTemplateData: any, countries: any }) => {
       this.createTemplateData = data.createTemplateData;
-      this.countries = data.countries;
     });
   }
 
@@ -76,8 +80,7 @@ export class CreateTemplateComponent implements OnInit {
     this.templateForm = this.formBuilder.group({
       'entity': ['', Validators.required],
       'type': ['', Validators.required],
-      'name': ['', Validators.required],
-      'countryId': ['', Validators.required]
+      'name': ['', Validators.required]
     });
   }
 
@@ -87,22 +90,24 @@ export class CreateTemplateComponent implements OnInit {
   buildDependencies() {
     const tenantIdentifier = 'default'; // update once global settings are setup.
     this.templateForm.get('entity').valueChanges.subscribe((value: any) => {
-      if (value === 0) { // client
+      this.templateTypes = this.createTemplateData.entities.filter((entity: any) => entity.code === value)[0]?.templateTypes;
+      if (value === 'CLIENT') { // client
         this.mappers.splice(0, 1, {
           mappersorder: 0,
           mapperskey: new UntypedFormControl('client'),
           mappersvalue: new UntypedFormControl('clients/{{clientId}}?tenantIdentifier=' + tenantIdentifier)
         });
-      } else { // loan
+        
+      } /*else { // loan product
         this.mappers.splice(0, 1, {
           mappersorder: 0,
           mapperskey: new UntypedFormControl('loan'),
           mappersvalue: new UntypedFormControl('loans/{{loanId}}?associations=all&tenantIdentifier=' + tenantIdentifier )
         });
-      }
+      }*/
       this.setEditorContent('');
     });
-    this.templateForm.get('entity').patchValue(0);
+    this.templateForm.get('entity').patchValue('CLIENT');
   }
 
   /**
@@ -169,6 +174,7 @@ export class CreateTemplateComponent implements OnInit {
         mapperskey: mapper.mapperskey.value,
         mappersvalue: mapper.mappersvalue.value
       })),
+      countryId: this.settingsService.getSelectedCountry()?.id,
       text: this.getEditorContent()
     };
     this.templateService.createTemplate(template).subscribe((response: any) => {

--- a/src/app/templates/edit-template/edit-template.component.html
+++ b/src/app/templates/edit-template/edit-template.component.html
@@ -11,7 +11,7 @@
           <mat-form-field fxFlex="48%">
             <mat-label>{{ 'labels.inputs.Entity' | translate }}</mat-label>
             <mat-select formControlName="entity">
-              <mat-option *ngFor="let entity of editTemplateData.entities" [value]="entity.id">
+              <mat-option *ngFor="let entity of editTemplateData.entities" [value]="entity.code">
                 {{ entity.name }}
               </mat-option>
             </mat-select>
@@ -20,13 +20,13 @@
           <mat-form-field fxFlex="48%">
             <mat-label>{{ 'labels.inputs.Type' | translate }}</mat-label>
             <mat-select formControlName="type">
-              <mat-option *ngFor="let type of editTemplateData.types" [value]="type.id">
+              <mat-option *ngFor="let type of templateTypes" [value]="type.code">
                 {{ type.name }}
               </mat-option>
             </mat-select>
           </mat-form-field>
   
-          <mat-form-field fxFlex="48%">
+          <mat-form-field fxFlex="98%">
             <mat-label>{{ 'labels.inputs.Name' | translate }}</mat-label>
             <input matInput formControlName="name">
           </mat-form-field>
@@ -76,7 +76,7 @@
 
       <mat-accordion>
 
-        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 0">
+        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 'CLIENT'">
   
           <mat-expansion-panel-header>
             <mat-panel-title>{{ 'labels.inputs.Client Parameters' | translate }}</mat-panel-title>
@@ -91,7 +91,7 @@
   
         </mat-expansion-panel>
 
-        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 1">
+        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 'LOAN'">
   
           <mat-expansion-panel-header>
             <mat-panel-title>{{ 'labels.inputs.Loan Parameters' | translate }}</mat-panel-title>
@@ -106,7 +106,7 @@
   
         </mat-expansion-panel>
 
-        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 1">
+        <mat-expansion-panel *ngIf="templateForm.controls.entity.value === 'LOAN'">
   
           <mat-expansion-panel-header>
             <mat-panel-title>{{ 'labels.inputs.Repayment Schedule Parameters' | translate }}</mat-panel-title>

--- a/src/app/templates/edit-template/edit-template.component.ts
+++ b/src/app/templates/edit-template/edit-template.component.ts
@@ -11,6 +11,7 @@ import { clientParameterLabels, loanParameterLabels, repaymentParameterLabels } 
 
 /** Custom Services */
 import { TemplatesService } from '../templates.service';
+import { locale } from 'moment';
 
 /**
  * Edit Template Component.
@@ -43,6 +44,10 @@ export class EditTemplateComponent implements OnInit {
   /** Repayment Parameter Labels */
   repaymentParameterLabels: string[] = repaymentParameterLabels;
 
+  /** Template entity types */
+  templateTypes: any[] = [];
+  allTemplateTypes: any[] = [];
+
   /**
    * Retrieves the template data from `resolve`.
    * @param {FormBuilder} formBuilder Form Builder.
@@ -56,6 +61,7 @@ export class EditTemplateComponent implements OnInit {
               private templateService: TemplatesService) {
     this.route.data.subscribe((data: { editTemplateData: any }) => {
       this.editTemplateData = data.editTemplateData;
+      this.allTemplateTypes = this.editTemplateData.types;
       this.mappers = this.editTemplateData.template.mappers
         .map((mapper: any) => ({
           mappersorder: mapper.mapperorder,
@@ -74,9 +80,13 @@ export class EditTemplateComponent implements OnInit {
    * Creates the template form.
    */
   createTemplateForm() {
+    console.log(this.editTemplateData);
+    console.log(this.allTemplateTypes.find((type: any) => type.name === this.editTemplateData.template.type)?.code);
+    const entity = this.editTemplateData.entities.find((entity: any) => entity.name === this.editTemplateData.template.entity);
+    this.templateTypes = entity?.templateTypes;
     this.templateForm = this.formBuilder.group({
-      'entity': [this.editTemplateData.entities.find((entity: any) => entity.name === this.editTemplateData.template.entity).id],
-      'type': [this.editTemplateData.types.find((type: any) => type.name === this.editTemplateData.template.type).id],
+      'entity': [this.editTemplateData.entities.find((entity: any) => entity.name === this.editTemplateData.template.entity).code],
+      'type': [this.templateTypes.find((type: any) => type.name === this.editTemplateData.template.type).code],
       'name': [this.editTemplateData.template.name]
     });
   }
@@ -87,19 +97,20 @@ export class EditTemplateComponent implements OnInit {
   buildDependencies() {
     const tenantIdentifier = 'default'; // update once global settings are setup.
     this.templateForm.get('entity').valueChanges.subscribe((value: any) => {
-      if (value === 0) { // client
+      this.templateTypes = this.editTemplateData.entities.filter((entity: any) => entity.code === value)[0]?.templateTypes;
+      if (value === 'CLIENT') { // client
         this.mappers.splice(0, 1, {
           mappersorder: 0,
           mapperskey: new UntypedFormControl('client'),
           mappersvalue: new UntypedFormControl('clients/{{clientId}}?tenantIdentifier=' + tenantIdentifier)
         });
-      } else { // loan
+      } /* else { // loan product
         this.mappers.splice(0, 1, {
           mappersorder: 0,
           mapperskey: new UntypedFormControl('loan'),
           mappersvalue: new UntypedFormControl('loans/{{loanId}}?associations=all&tenantIdentifier=' + tenantIdentifier )
         });
-      }
+      } */
       this.setEditorContent('');
     });
   }
@@ -168,7 +179,8 @@ export class EditTemplateComponent implements OnInit {
         mapperskey: mapper.mapperskey.value,
         mappersvalue: mapper.mappersvalue.value
       })),
-      text: this.getEditorContent()
+      text: this.getEditorContent(),
+      locale: 'en',
     };
     this.templateService.updateTemplate(template, this.editTemplateData.template.id).subscribe(() => {
       this.router.navigate(['../'], { relativeTo: this.route });

--- a/src/app/templates/edit-template/edit-template.component.ts
+++ b/src/app/templates/edit-template/edit-template.component.ts
@@ -11,7 +11,6 @@ import { clientParameterLabels, loanParameterLabels, repaymentParameterLabels } 
 
 /** Custom Services */
 import { TemplatesService } from '../templates.service';
-import { locale } from 'moment';
 
 /**
  * Edit Template Component.
@@ -80,13 +79,11 @@ export class EditTemplateComponent implements OnInit {
    * Creates the template form.
    */
   createTemplateForm() {
-    console.log(this.editTemplateData);
-    console.log(this.allTemplateTypes.find((type: any) => type.name === this.editTemplateData.template.type)?.code);
     const entity = this.editTemplateData.entities.find((entity: any) => entity.name === this.editTemplateData.template.entity);
     this.templateTypes = entity?.templateTypes;
     this.templateForm = this.formBuilder.group({
-      'entity': [this.editTemplateData.entities.find((entity: any) => entity.name === this.editTemplateData.template.entity).code],
-      'type': [this.templateTypes.find((type: any) => type.name === this.editTemplateData.template.type).code],
+      'entity': [this.editTemplateData.entities.find((entity: any) => entity.name === this.editTemplateData.template.entity)?.code],
+      'type': [this.templateTypes.find((type: any) => type.name === this.editTemplateData.template.type)?.code],
       'name': [this.editTemplateData.template.name]
     });
   }

--- a/src/app/templates/templates-routing.module.ts
+++ b/src/app/templates/templates-routing.module.ts
@@ -33,6 +33,7 @@ const routes: Routes = [
           component: TemplatesComponent,
           resolve: {
             templates: TemplatesResolver,
+            entityAndTypesTemplateData: CreateTemplateResolver
           },
         },
         {

--- a/src/app/templates/templates.component.html
+++ b/src/app/templates/templates.component.html
@@ -5,12 +5,44 @@
 
 <div class="container">
 
+  <div>
+  <form class="search-form" *ngIf="templateSearchForm" [formGroup]="templateSearchForm">
   <div fxLayout="row" fxLayoutGap="20px">
-    <mat-form-field fxFlex>
-      <mat-label>{{ 'labels.buttons.Filter' | translate }}</mat-label>
-      <input matInput (keyup)="applyFilter($event.target.value)">
-    </mat-form-field>
+    <div fxFlex="calc(33% - 1rem)">
+      <ng-select
+        #templateEntity
+        [items]="entityAndTypesTemplateData.entities"
+        bindLabel="name"
+        bindValue="code"
+        placeholder="{{ 'labels.inputs.Entity' | translate }}"
+        formControlName="templateEntity"
+        aria-labelledby="entity"
+        [virtualScroll]="true"
+      >
+      </ng-select>
+    </div>
+
+    <div fxFlex="calc(33% - 1rem)">
+      <ng-select
+        #templateType
+        [items]="templateTypes"
+        bindLabel="name"
+        bindValue="code"
+        placeholder="{{ 'labels.inputs.Type' | translate }}"
+        formControlName="templateType"
+        aria-labelledby="type"
+        [virtualScroll]="true"
+      >
+      </ng-select>
+    </div>
+
+  <div fxFlex="calc(33% - 1rem)">
+    <mat-checkbox formControlName="activeTemplates" #activeTemplates labelPosition="after">{{ 'labels.commons.includeOnlyActiveRecords' | translate }}
+    </mat-checkbox>
   </div>
+  </div>
+</form>
+</div>
 
   <div class="mat-elevation-z8">
 
@@ -29,6 +61,20 @@
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Name' | translate }}</th>
         <td mat-cell *matCellDef="let template"> {{ template.name }} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="isActive">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Status' | translate }}</th>
+        <td mat-cell *matCellDef="let template">
+          <div [className]="template.active | statusLookup">
+            <fa-icon
+              matTooltip="{{ template.active ? 'Active' : 'Inactive' }}"
+              matTooltipPosition="right"
+              icon="circle"
+              size="lg"
+            ></fa-icon>
+          </div>
+        </td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/templates/templates.component.html
+++ b/src/app/templates/templates.component.html
@@ -68,7 +68,7 @@
         <td mat-cell *matCellDef="let template">
           <div [className]="template.active | statusLookup">
             <fa-icon
-              matTooltip="{{ template.active ? 'Active' : 'Inactive' }}"
+              matTooltip="{{ getIsActiveLabel(template.active)}}"
               matTooltipPosition="right"
               icon="circle"
               size="lg"

--- a/src/app/templates/templates.component.scss
+++ b/src/app/templates/templates.component.scss
@@ -5,3 +5,11 @@ table {
     cursor: pointer;
   }
 }
+
+.display-none{
+  display: none !important;
+}
+
+.search-form {
+  margin-bottom: 1rem;
+}

--- a/src/app/templates/templates.component.ts
+++ b/src/app/templates/templates.component.ts
@@ -9,6 +9,7 @@ import { SettingsService } from 'app/settings/settings.service';
 import { merge, Subject } from 'rxjs';
 import { takeUntil, tap } from 'rxjs/operators';
 import { TemplatesService } from './templates.service';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * Templates component.
@@ -50,6 +51,7 @@ export class TemplatesComponent implements OnInit, AfterViewInit, OnDestroy {
     private route: ActivatedRoute, 
     protected formBuilder: UntypedFormBuilder,
     private settingsService: SettingsService,
+    private translateService: TranslateService,
     private templateService: TemplatesService) {
     this.route.data.subscribe((data: { templates: any, entityAndTypesTemplateData: any }) => {
       this.templatesData = data.templates?.content || [];
@@ -177,6 +179,11 @@ loadConsentData() {
       }
     });
 
+ }
+
+  getIsActiveLabel(isActive: boolean): string {
+    const activeLabelKey = isActive ? 'labels.inputs.Active' : 'labels.catalogs.Inactive';
+   return this.translateService.instant(activeLabelKey);
  }
 
   ngOnDestroy(): void {

--- a/src/app/templates/templates.component.ts
+++ b/src/app/templates/templates.component.ts
@@ -168,7 +168,7 @@ loadConsentData() {
     .subscribe({
       next: (response: any) => {
         this.templatesData = response?.content || [];
-        this.dataSource = new MatTableDataSource(this.templatesData);
+        this.dataSource.data = this.templatesData;
         this.totalElements = response?.total || 0;
       },
       error: (err) => {

--- a/src/app/templates/templates.component.ts
+++ b/src/app/templates/templates.component.ts
@@ -1,9 +1,14 @@
 /** Angular Imports */
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute } from '@angular/router';
+import { SettingsService } from 'app/settings/settings.service';
+import { merge, Subject } from 'rxjs';
+import { takeUntil, tap } from 'rxjs/operators';
+import { TemplatesService } from './templates.service';
 
 /**
  * Templates component.
@@ -13,36 +18,88 @@ import { ActivatedRoute } from '@angular/router';
   templateUrl: './templates.component.html',
   styleUrls: ['./templates.component.scss']
 })
-export class TemplatesComponent implements OnInit {
+export class TemplatesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   /** Templates data. */
   templatesData: any;
+  entityAndTypesTemplateData: any;
+  templateTypes: any[] = [];
   /** Columns to be displayed in templates table. */
-  displayedColumns: string[] = ['entity', 'type', 'name'];
+  displayedColumns: string[] = ['entity', 'type', 'name', 'isActive'];
   /** Data source for templates table. */
   dataSource: MatTableDataSource<any>;
+
+  /** Subject for component destruction. */
+  private readonly destroy$ = new Subject<void>();
 
   /** Paginator for templates table. */
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
   /** Sorter for templates table. */
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
+  pageSize = 10;
+  pageIndex = 0;
+  totalElements = 0;
+  templateSearchForm!: UntypedFormGroup;
+
   /**
    * Retrieves the templates data from `resolve`.
    * @param {ActivatedRoute} route Activated Route.
    */
-  constructor(private route: ActivatedRoute) {
-    this.route.data.subscribe(( data: { templates: any }) => {
-      this.templatesData = data.templates;
+  constructor(
+    private route: ActivatedRoute, 
+    protected formBuilder: UntypedFormBuilder,
+    private settingsService: SettingsService,
+    private templateService: TemplatesService) {
+    this.route.data.subscribe((data: { templates: any, entityAndTypesTemplateData: any }) => {
+      this.templatesData = data.templates?.content || [];
+      this.entityAndTypesTemplateData = data.entityAndTypesTemplateData;
     });
   }
+  ngAfterViewInit(): void {
+    if (!this.paginator || !this.sort) {
+      console.error('Paginator or Sort not initialized');
+      return;
+    }
 
-  /**
-   * Filters data in templates table based on passed value.
-   * @param {string} filterValue Value to filter data.
-   */
-  applyFilter(filterValue: string) {
-    this.dataSource.filter = filterValue.trim().toLowerCase();
+    // Assign paginator and sort to dataSource
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+
+    this.sort.sortChange
+    .pipe(takeUntil(this.destroy$))
+    .subscribe(() => {
+      if (this.paginator) {
+        this.paginator.pageIndex = 0;
+      }
+    });
+
+    // Subscribe to form changes after view init
+    this.templateSearchForm.valueChanges
+      .pipe(
+        takeUntil(this.destroy$),
+        tap(() => {
+          if (this.paginator) {
+            this.paginator.pageIndex = 0;
+          }
+          this.loadConsentData();
+        })
+      ).subscribe();
+
+      merge(
+        this.sort.sortChange,
+        this.paginator.page
+      ).pipe(
+          takeUntil(this.destroy$),
+          tap(() => {
+            this.pageIndex = this.paginator.pageIndex;
+            this.pageSize = this.paginator.pageSize;
+            this.loadConsentData();
+          })
+        ).subscribe();
+
+        // Load initial data
+    this.loadConsentData();
   }
 
   /**
@@ -50,6 +107,8 @@ export class TemplatesComponent implements OnInit {
    */
   ngOnInit() {
     this.setTemplates();
+    this.createTemplateSearchForm();
+    this.buildTemplateTypeDependencies();
   }
 
   /**
@@ -60,5 +119,69 @@ export class TemplatesComponent implements OnInit {
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
   }
+
+  createTemplateSearchForm(): void {
+    this.templateSearchForm = this.formBuilder.group({
+      templateEntity: [null],
+      templateType: [null],
+      activeTemplates: [null]
+    });
+}
+
+/**
+   * Subscribe to value changes of entity to set template types.
+   */
+buildTemplateTypeDependencies() {
+  this.templateSearchForm.get('templateEntity').valueChanges.subscribe((value: any) => {
+    this.templateSearchForm.get('templateType').patchValue(null);
+    this.templateTypes = this.entityAndTypesTemplateData.entities.filter((entity: any) => entity.code === value)[0]?.templateTypes;
+  });
+}
+
+loadConsentData() {
+  const pageIndex = this.paginator ? this.paginator.pageIndex : this.pageIndex;
+  const pageSize = this.paginator ? this.paginator.pageSize : this.pageSize;
+  const formValues = this.templateSearchForm.value;
+
+  const params: any = {
+    pageNumber: pageIndex,
+    pageSize: pageSize
+  };
+
+  if (formValues.activeTemplates) {
+    params.activeOnly = formValues.activeTemplates;
+  }
+  let countryId = this.settingsService.getSelectedCountry()?.id;
+  if (countryId) {
+    params.countryId = countryId;
+  }
+  if (formValues.templateType) {
+    params.templateType = formValues.templateType;
+  }
+
+  if (formValues.templateEntity) {
+    params.templateEntity = formValues.templateEntity;
+  }
+
+  this.templateService.getTemplates(params)
+  .pipe(takeUntil(this.destroy$))
+    .subscribe({
+      next: (response: any) => {
+        this.templatesData = response?.content || [];
+        this.dataSource = new MatTableDataSource(this.templatesData);
+        this.totalElements = response?.total || 0;
+      },
+      error: (err) => {
+        console.error('Error fetching consents:', err);
+        this.dataSource.data = [];
+      }
+    });
+
+ }
+
+  ngOnDestroy(): void {
+      this.destroy$.next();
+      this.destroy$.complete();
+    }
 
 }

--- a/src/app/templates/templates.component.ts
+++ b/src/app/templates/templates.component.ts
@@ -134,7 +134,7 @@ export class TemplatesComponent implements OnInit, AfterViewInit, OnDestroy {
    * Subscribe to value changes of entity to set template types.
    */
 buildTemplateTypeDependencies() {
-  this.templateSearchForm.get('templateEntity').valueChanges.subscribe((value: any) => {
+  this.templateSearchForm.get('templateEntity').valueChanges.pipe(takeUntil(this.destroy$)).subscribe((value: any) => {
     this.templateSearchForm.get('templateType').patchValue(null);
     this.templateTypes = this.entityAndTypesTemplateData.entities.filter((entity: any) => entity.code === value)[0]?.templateTypes;
   });

--- a/src/app/templates/templates.module.ts
+++ b/src/app/templates/templates.module.ts
@@ -12,6 +12,7 @@ import { TemplatesComponent } from './templates.component';
 import { ViewTemplateComponent } from './view-template/view-template.component';
 import { EditTemplateComponent } from './edit-template/edit-template.component';
 import { CreateTemplateComponent } from './create-template/create-template.component';
+import { PipesModule } from 'app/pipes/pipes.module';
 
 /**
  * Templates Module
@@ -23,6 +24,7 @@ import { CreateTemplateComponent } from './create-template/create-template.compo
     CKEditorModule,
     SharedModule,
     DirectivesModule,
+    PipesModule,
     TemplatesRoutingModule
   ],
   declarations: [

--- a/src/app/templates/templates.service.ts
+++ b/src/app/templates/templates.service.ts
@@ -21,8 +21,14 @@ export class TemplatesService {
   /**
    * @returns {Observable<any>} Templates data
    */
-  getTemplates(): Observable<any> {
-    return this.http.get('/templates');
+  getTemplates(params: any): Observable<any> {
+    let httpParams = new HttpParams();
+    Object.keys(params).forEach(key => {
+      if (params[key] !== null && params[key] !== undefined) {
+        httpParams = httpParams.set(key, params[key]);
+      }
+    });
+    return this.http.get('/templates', { params: httpParams });
   }
 
   /**
@@ -64,6 +70,15 @@ export class TemplatesService {
    */
   updateTemplate(templateData: any, templateId: any): Observable<any>  {
     return this.http.put(`/templates/${templateId}`, templateData);
+  }
+
+  /**
+   * Call API to activate/deactivate a template by id
+   * @param templateId
+   * @returns
+   */
+  activateOrDeactivateTemplate(templateId: string, isActivate: boolean): Observable<any> {
+    return this.http.post(`/templates/${templateId}/status`, { isActivate });
   }
 
   /**

--- a/src/app/templates/view-template/view-template.component.html
+++ b/src/app/templates/view-template/view-template.component.html
@@ -3,6 +3,11 @@
   <button mat-raised-button color="primary" [routerLink]="['edit']" *mifosxHasPermission="'UPDATE_TEMPLATE'">
     <fa-icon icon="edit"></fa-icon>&nbsp;&nbsp;{{ 'labels.buttons.Edit' | translate }}</button>
 
+  <button mat-raised-button color="primary" (click)="activateOrDeactivateTemplate(templateData.id, !templateData.active)" *mifosxHasPermission="'ACTIVATE_DEACTIVATE_TEMPLATE'">
+    <span *ngIf="templateData.active"><fa-icon icon="ban"></fa-icon>&nbsp;&nbsp;{{ 'labels.buttons.Deactivate' | translate }}</span>
+    <span *ngIf="!templateData.active"><em class="fa fa-unlock-alt"></em>&nbsp;&nbsp;{{ 'labels.buttons.Activate' | translate }}</span>
+  </button>
+
   <button mat-raised-button color="warn" (click)="delete()" *mifosxHasPermission="'DELETE_TEMPLATE'">
     <fa-icon icon="trash"></fa-icon>&nbsp;&nbsp;{{ 'labels.buttons.Delete' | translate }}</button>
 

--- a/src/app/templates/view-template/view-template.component.ts
+++ b/src/app/templates/view-template/view-template.component.ts
@@ -12,6 +12,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { ConfirmationDialogComponent } from 'app/shared/confirmation-dialog/confirmation-dialog.component';
 import { extract } from 'app/core/i18n/i18n.service';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * View Template Component.
@@ -37,6 +38,7 @@ export class ViewTemplateComponent implements OnDestroy {
   constructor(private route: ActivatedRoute,
               private templatesService: TemplatesService,
               private router: Router,
+              private translateService: TranslateService,
               private dialog: MatDialog) {
     this.route.data.subscribe((data: { template: any }) => {
       this.templateData = data.template;
@@ -62,8 +64,17 @@ export class ViewTemplateComponent implements OnDestroy {
   }
 
   activateOrDeactivateTemplate(templateId: any, isActivate: boolean) {
-    const templateActionHeading = isActivate ? 'Activate Template' : 'Deactivate Template';
-    const dialogContext = isActivate ? 'This will deactivate current active template and activate the selected one. Do you want to proceed?' : 'This will leave this template type without active template. Do you want to proceed?';
+    const headingKey = isActivate
+    ? 'labels.heading.activateTemplateHeading'
+    : 'labels.heading.deactivateTemplateHeading';
+
+    const contextKey = isActivate
+      ? 'labels.heading.confirmTemplateActivation'
+      : 'labels.heading.confirmTemplateDeactivation';
+
+    const templateActionHeading = this.translateService.instant(headingKey);
+    const dialogContext = this.translateService.instant(contextKey);
+
     const disableOutletDialogRef = this.dialog.open(ConfirmationDialogComponent, {
       data: { heading: templateActionHeading, dialogContext: dialogContext }
     });

--- a/src/app/templates/view-template/view-template.component.ts
+++ b/src/app/templates/view-template/view-template.component.ts
@@ -1,5 +1,5 @@
 /** Angular Imports */
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -8,6 +8,10 @@ import { TemplatesService } from '../templates.service';
 
 /** Custom Components */
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { ConfirmationDialogComponent } from 'app/shared/confirmation-dialog/confirmation-dialog.component';
+import { extract } from 'app/core/i18n/i18n.service';
 
 /**
  * View Template Component.
@@ -17,10 +21,11 @@ import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.co
   templateUrl: './view-template.component.html',
   styleUrls: ['./view-template.component.scss']
 })
-export class ViewTemplateComponent {
+export class ViewTemplateComponent implements OnDestroy {
 
   /** Template Data */
   templateData: any;
+  private readonly destroy$ = new Subject<void>();
 
   /**
    * Retrieves the template data from `resolve`.
@@ -48,11 +53,36 @@ export class ViewTemplateComponent {
     deleteTemplateDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
         this.templatesService.deleteTemplate(this.templateData.id)
+          .pipe(takeUntil(this.destroy$))
           .subscribe(() => {
             this.router.navigate(['/templates']);
           });
       }
     });
   }
+
+  activateOrDeactivateTemplate(templateId: any, isActivate: boolean) {
+    const templateActionHeading = isActivate ? 'Activate Template' : 'Deactivate Template';
+    const dialogContext = isActivate ? 'This will deactivate current active template and activate the selected one. Do you want to proceed?' : 'This will leave this template type without active template. Do you want to proceed?';
+    const disableOutletDialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      data: { heading: templateActionHeading, dialogContext: dialogContext }
+    });
+    disableOutletDialogRef.afterClosed()
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((response: any) => {
+          if (response.confirm) {
+            this.templatesService.activateOrDeactivateTemplate(templateId, isActivate)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(() => {
+              this.router.navigate(['../'], { relativeTo: this.route });
+            });
+          }
+        });
+    }
+
+    ngOnDestroy(): void {
+      this.destroy$.next();
+      this.destroy$.complete();
+    }
 
 }

--- a/src/app/templates/view-template/view-template.component.ts
+++ b/src/app/templates/view-template/view-template.component.ts
@@ -53,7 +53,7 @@ export class ViewTemplateComponent implements OnDestroy {
       data: { deleteContext: `template ${this.templateData.id}` }
     });
     deleteTemplateDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.templatesService.deleteTemplate(this.templateData.id)
           .pipe(takeUntil(this.destroy$))
           .subscribe(() => {
@@ -81,7 +81,7 @@ export class ViewTemplateComponent implements OnDestroy {
     disableOutletDialogRef.afterClosed()
         .pipe(takeUntil(this.destroy$))
         .subscribe((response: any) => {
-          if (response.confirm) {
+          if (response?.confirm) {
             this.templatesService.activateOrDeactivateTemplate(templateId, isActivate)
             .pipe(takeUntil(this.destroy$))
             .subscribe(() => {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1094,7 +1094,8 @@
       "Second External ID": "Second External ID",
       "Source Office": "Source Office",
       "Destination Office": "Destination Office",
-      "Is the OU a country": "Is OU a Country"
+      "Is the OU a country": "Is OU a Country",
+      "includeOnlyActiveRecords": "Active Only"
     },
     "heading": {
       "Actions": "Actions",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1454,7 +1454,11 @@
       "Delete Interest Rate Chart": "Delete Interest Rate Chart",
       "Floating Rate Period": "Floating Rate Period",
       "Status": "Status",
-      "Sub Status": "Sub Status"
+      "Sub Status": "Sub Status",
+      "activateTemplateHeading": "Activate Template",
+      "deactivateTemplateHeading": "Deactivate Template",
+      "confirmTemplateActivation": "This will deactivate current active template and activate the selected one. Do you want to proceed?",
+      "confirmTemplateDeactivation": "This will leave this template type without active template. Do you want to proceed?"
     },
     "inputs": {
       "accounting": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1090,7 +1090,8 @@
       "Second External ID": "Deuxième ID Externe",
       "Source Office": "Bureau Source",
       "Destination Office": "Bureau de Destination",
-      "Is the OU a country": "L'UO est-elle un Pays"
+      "Is the OU a country": "L'UO est-elle un Pays",
+      "includeOnlyActiveRecords": "Actifs uniquement"
     },
     "heading": {
       "Actions": "Actions",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1449,7 +1449,11 @@
       "successfully select option": "avec succès. Veuillez sélectionner parmi les options ci-dessous pour continuer.",
       "Map Charge-off reasons to Expense accounts": "Cartographier les motifs de radiation sur les comptes de dépenses",
       "Status": "Statut",
-      "Sub Status": "Sous-statut"
+      "Sub Status": "Sous-statut",
+      "activateTemplateHeading": "Activer le modèle",
+      "deactivateTemplateHeading": "Désactiver le modèle",
+      "confirmTemplateActivation": "Cela désactivera le modèle actif actuel et activera celui sélectionné. Voulez-vous continuer ?",
+      "confirmTemplateDeactivation": "Cela laissera ce type de modèle sans modèle actif. Voulez-vous continuer ?"
     },
     "inputs": {
       "accounting": {

--- a/src/assets/translations/sw-KE.json
+++ b/src/assets/translations/sw-KE.json
@@ -1452,7 +1452,11 @@
       "Delete Interest Rate Chart": "Futa Chati ya Kiwango cha Riba",
       "Floating Rate Period": "Kipindi cha Kiwango cha Kuelea",
       "Status": "Hali",
-      "Sub Status": "Hali Ndogo"
+      "Sub Status": "Hali Ndogo",
+      "activateTemplateHeading": "Washa Kiolezo",
+      "deactivateTemplateHeading": "Zima Kiolezo",
+      "confirmTemplateActivation": "Hii itazima kiolezo cha hali halisi cha sasa na kuwezesha kilichochaguliwa. Je, ungependa kuendelea?",
+      "confirmTemplateDeactivation": "Hii itaacha aina hii ya kiolezo bila kiolezo cha hali halisi. Je, ungependa kuendelea?"
     },
     "inputs": {
       "accounting": {

--- a/src/assets/translations/sw-KE.json
+++ b/src/assets/translations/sw-KE.json
@@ -1092,7 +1092,8 @@
       "Second External ID": "Kitambulisho cha Pili cha Nje",
       "Source Office": "Ofisi ya Chanzo",
       "Destination Office": "Ofisi ya Marudio",
-      "Is the OU a country": "Je, OU ni Nchi"
+      "Is the OU a country": "Je, OU ni Nchi",
+      "includeOnlyActiveRecords": "Inaotumika tu"
     },
     "heading": {
       "Actions": "Vitendo",


### PR DESCRIPTION
## Description
- Refactor Template Configuration to include client consent
- Ability to activate/deactivate a template per country/entity/type

## Changes Included in PR
- [CP-3666- Dynamic Consent Message Configuration](https://oneacrefund.atlassian.net/browse/CP-3666)

## Screenshots, if any

<img width="1309" height="609" alt="Screenshot 2026-01-23 at 10 05 14" src="https://github.com/user-attachments/assets/ed506454-3a6c-41ad-a3ae-2731aa6c4d5e" />


<img width="1139" height="694" alt="Screenshot 2026-01-23 at 10 05 42" src="https://github.com/user-attachments/assets/512361e0-79fc-4ded-85f2-15c778511c6c" />


<img width="1078" height="669" alt="Screenshot 2026-01-23 at 10 05 58" src="https://github.com/user-attachments/assets/9fc59c05-4ea2-4032-93e5-2f16301ae00e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template activate/deactivate action with confirmation dialog and toggle button
  * New Active status column with visual indicator

* **Improvements**
  * Enhanced filtering: entity, type, and active-status controls; pagination and sorting added
  * Automatic country selection from user settings (country selector removed)
  * Form/layout refinements and dependent type selection; editor and view workflows updated

* **Documentation**
  * Added top-level release entry and new translations including "Active Only" and activation/deactivation messages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->