### PR TITLE
chore(CP-4004) - Disabling the notification tray for now since it's not being consumed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@
 ## Version 1.4.6 - Community 1.0.0
     * Configurations
         * [CP-3666] - Refactor Template Configuration with HTML Support Per Country
+    * Navigation Bar
+        * [CP-4004] - Disabling the notification tray for now since it's not being consumed   
 
 ## Version 1.4.1 - Community 1.0.0
 

--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -84,7 +84,7 @@
 
   <mifosx-theme-picker fxHide.lt-md></mifosx-theme-picker>
 
-  <mifosx-notifications-tray fxHide.lt-md></mifosx-notifications-tray>
+  <!-- <mifosx-notifications-tray fxHide.lt-md></mifosx-notifications-tray> -->
 
   <button mat-icon-button class="ml-1 img-button" [matMenuTriggerFor]="applicationMenu">
     <img src="assets/images/user_placeholder.png" />

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -17,7 +17,6 @@ import { EnableDialogComponent } from './enable-dialog/enable-dialog.component';
 import { DisableDialogComponent } from './disable-dialog/disable-dialog.component';
 import { ConfirmationDialogComponent } from './confirmation-dialog/confirmation-dialog.component';
 import { ErrorDialogComponent } from './error-dialog/error-dialog.component';
-import { NotificationsTrayComponent } from './notifications-tray/notifications-tray.component';
 import { SearchToolComponent } from './search-tool/search-tool.component';
 import { KeyboardShortcutsDialogComponent } from './keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.component';
 import { ServerSelectorComponent } from './server-selector/server-selector.component';
@@ -62,7 +61,6 @@ import { NgOtpInputModule } from 'ng-otp-input';
     ConfirmationDialogComponent,
     KeyboardShortcutsDialogComponent,
     ErrorDialogComponent,
-    NotificationsTrayComponent,
     SearchToolComponent,
     ServerSelectorComponent,
     OfficeTreeViewComponent,
@@ -75,7 +73,6 @@ import { NgOtpInputModule } from 'ng-otp-input';
     LanguageSelectorComponent,
     ServerSelectorComponent,
     ThemePickerComponent,
-    NotificationsTrayComponent,
     SearchToolComponent,
     ErrorDialogComponent,
     CommonModule,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Notification tray disabled: the tray is no longer rendered or accessible in the app’s interface; navigation bar reflects this change.

* **Documentation**
  * Release notes updated for version 1.4.6 to document the navigation bar update and the notification tray being disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->