### PR TITLE
HQX-235 Savings bulk transactions improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@
         * [CP-4057] - Improve Rahisi Model UI to show more details and make it more user friendly
     * System
         * [FOX-202] - Resolve errors during create/modify custom fields of dropdown type
+    * Savings Accounts & Products
+        * [HQX-235] - Ability to download savings transaction template without selecting an office
 
 ## Version 1.4.9.1 - Community 1.0.0
     * Clients

--- a/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.ts
+++ b/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.ts
@@ -256,20 +256,20 @@ export class ViewBulkImportComponent implements OnInit {
         return !this.getSelectedOfficeId();
       case BulkImportsConstants.SAVINGS_TRANSACTIONS_IMPORT:
         const countryId = this.bulkImportForm.get('countryId')?.value;
-      const officeId = this.getSelectedOfficeId();
-      
-      // Enable if country selected but no office selected
-      if (countryId && !officeId) {
-        return false;
-      }
-      
-      // If office is selected, require lowest OU to be selected
-      if (officeId) {
-        return !this.getEffectiveOfficeId();
-      }
-      
-      // Disable if no country selected
-      return true;
+        const officeId = this.getSelectedOfficeId();
+        
+        // Enable if country selected but no office selected
+        if (countryId && !officeId) {
+          return false;
+        }
+        
+        // If office is selected, require lowest OU to be selected
+        if (officeId) {
+          return !this.getEffectiveOfficeId();
+        }
+        
+        // Disable if no country selected
+        return true;
 
       default:
         return false;

--- a/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.ts
+++ b/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.ts
@@ -255,7 +255,21 @@ export class ViewBulkImportComponent implements OnInit {
       case BulkImportsConstants.CLIENT_TRANSFER_IMPORT:
         return !this.getSelectedOfficeId();
       case BulkImportsConstants.SAVINGS_TRANSACTIONS_IMPORT:
+        const countryId = this.bulkImportForm.get('countryId')?.value;
+      const officeId = this.getSelectedOfficeId();
+      
+      // Enable if country selected but no office selected
+      if (countryId && !officeId) {
+        return false;
+      }
+      
+      // If office is selected, require lowest OU to be selected
+      if (officeId) {
         return !this.getEffectiveOfficeId();
+      }
+      
+      // Disable if no country selected
+      return true;
 
       default:
         return false;
@@ -348,6 +362,7 @@ export class ViewBulkImportComponent implements OnInit {
       case BulkImportsConstants.CLIENT_TRANSFER_IMPORT:
       case BulkImportsConstants.GROUP_OFFICE_TRANSFER_IMPORT:
       case BulkImportsConstants.CLIENT_GROUP_REMOVAL_IMPORT:
+      case BulkImportsConstants.SAVINGS_TRANSACTIONS_IMPORT:
         countryId = this.bulkImportForm.get('countryId')?.value;
         if (!countryId) {
           return this.alertService.alert({

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -14,7 +14,7 @@ export const environment = {
   fineractPlatformTenantId: window['env']['fineractPlatformTenantId'] || 'default',
   // For connecting to others servers running elsewhere update the base API URL
   baseApiUrls: window['env']['fineractApiUrls'] ||
-    'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://loans.integration.oneacrefund.org,https://localhost:8443',
+    'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://loans.dev.oneacrefund.org,https://localhost:8443',
   // For connecting to server running elsewhere set the base API URL
   baseApiUrl: window['env']['baseApiUrl'] || 'https://localhost:8443',
   allowServerSwitch: env.allow_switching_backend_instance,
@@ -23,10 +23,10 @@ export const environment = {
   serverUrl: '',
   oauth: {
     enabled: true,  // For connecting to Mifos X using OAuth2 Authentication change the value to true
-    serverUrl: window['env']['authServerUrl'] || 'https://accounts.integration.oneacrefund.org',
+    serverUrl: window['env']['authServerUrl'] || 'https://accounts.dev.oneacrefund.org',
     realm: window['env']['keycloakRealm'] || 'OneAcreFund',
     client_id: window['env']['keycloakClientId'] || 'fineract',
-    tokenUrl: `https://loans.integration.oneacrefund.org/auth/realms/OneAcreFund/protocol/openid-connect/token`,
+    tokenUrl: `https://loans.dev.oneacrefund.org/auth/realms/OneAcreFund/protocol/openid-connect/token`,
     redirectUri: window['env']['homeURL'] || 'http://localhost:4200/home'
   },
   defaultLanguage: window['env']['defaultLanguage'] || 'en-US',

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -10,19 +10,19 @@ export const environment = {
   // For connecting to others servers running elsewhere update the base API URL
   baseApiUrls:
     window['env']['fineractApiUrls'] ||
-    'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://loans.integration.oneacrefund.org,https://localhost:8443',
+    'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://loans.dev.oneacrefund.org,https://localhost:8443',
   // For connecting to server running elsewhere set the base API URL
-  baseApiUrl: window['env']['fineractApiUrl'] || 'https://loans.integration.oneacrefund.org',
+  baseApiUrl: window['env']['fineractApiUrl'] || 'https://loans.dev.oneacrefund.org',
   allowServerSwitch: env.allow_switching_backend_instance,
   apiProvider: window['env']['apiProvider'] || '/fineract-provider/api',
   apiVersion: window['env']['apiVersion'] || '/v1',
   serverUrl: '',
   oauth: {
     enabled: true, // For connecting to Mifos X using OAuth2 Authentication change the value to true
-    serverUrl: window['env']['authServerUrl'] || 'https://accounts.integration.oneacrefund.org',
+    serverUrl: window['env']['authServerUrl'] || 'https://accounts.dev.oneacrefund.org',
     realm: window['env']['keycloakRealm'] || 'OneAcreFund',
     client_id: window['env']['keycloakClientId'] || 'fineract',
-    tokenUrl: window['env']['keycloakTokenUrl'] || "https://loans.integration.oneacrefund.org/auth/realms/OneAcreFund/protocol/openid-connect/token",
+    tokenUrl: window['env']['keycloakTokenUrl'] || "https://loans.dev.oneacrefund.org/auth/realms/OneAcreFund/protocol/openid-connect/token",
     redirectUri: window['env']['homeURL'] || 'http://localhost:4200/home',
   },
   defaultLanguage: window['env']['defaultLanguage'] || 'en-US',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -15,21 +15,21 @@ export const environment = {
   // For connecting to others servers running elsewhere update the base API URL
   baseApiUrls:
     window['env']['fineractApiUrls'] ||
-    'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://loans.integration.oneacrefund.org,https://localhost:8443',
+    'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://loans.dev.oneacrefund.org,https://localhost:8443',
   // For connecting to server running elsewhere set the base API URL
-  baseApiUrl: window['env']['baseApiUrl'] || 'https://loans.integration.oneacrefund.org',
+  baseApiUrl: window['env']['baseApiUrl'] || 'https://loans.dev.oneacrefund.org',
   allowServerSwitch: env.allow_switching_backend_instance,
   apiProvider: window['env']['apiProvider'] || '/fineract-provider/api',
   apiVersion: window['env']['apiVersion'] || '/v1',
   serverUrl: '',
   oauth: {
     enabled: true, // For connecting to Mifos X using OAuth2 Authentication change the value to true
-    serverUrl: window['env']['authServerUrl'] || 'https://accounts.integration.oneacrefund.org',
+    serverUrl: window['env']['authServerUrl'] || 'https://accounts.dev.oneacrefund.org',
     realm: window['env']['keycloakRealm'] || 'OneAcreFund',
     client_id: window['env']['keycloakClientId'] || 'fineract',
     tokenUrl:
       window['env']['keycloakTokenUrl'] ||
-      `https://loans.integration.oneacrefund.org/auth/realms/OneAcreFund/protocol/openid-connect/token`,
+      `https://loans.dev.oneacrefund.org/auth/realms/OneAcreFund/protocol/openid-connect/token`,
     redirectUri: window['env']['homeURL'] || 'http://localhost:4200/home',
   },
   defaultLanguage: window['env']['defaultLanguage'] || 'en-US',


### PR DESCRIPTION
## Description
- Ability to download savings transaction template without selecting an office
- No data is pre-populated if no office is selected

## Changes Included in PR
- [HQX-235 - Bulk withdrawal of savings improvement](https://oneacrefund.atlassian.net/browse/HQX-235)

## Screenshots, if any
<img width="1269" height="321" alt="Screenshot 2026-05-11 at 11 50 23" src="https://github.com/user-attachments/assets/98d9c3c1-f6c6-4af1-be13-3521fd57f0df" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk import: savings transaction template download now requires a selected country and respects office-selection rules.

* **Bug Fixes**
  * Improved validation and upload behavior for savings bulk transactions to prevent invalid country/office combinations.

* **Chores**
  * Development environment defaults updated to use dev.oneacrefund.org for backend and OAuth endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-acre-fund/fineract-frontend-v2/pull/322)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->