### PR TITLE
ci: migrate container registry from ACR to AWS ECR

### DIFF
--- a/.github/actions/helm_fineract_frontend/action.yml
+++ b/.github/actions/helm_fineract_frontend/action.yml
@@ -66,8 +66,8 @@ inputs:
     description: The URL of the APM server.
   APM_ACTIVE:
     description: Whether APM is active or not.
-    type: boolean
-    default: true
+    required: false
+    default: 'true'
 
 runs:
   using: composite

--- a/.github/actions/helm_fineract_frontend/action.yml
+++ b/.github/actions/helm_fineract_frontend/action.yml
@@ -2,14 +2,14 @@ name: Helm Fineract Frontend
 description: GitHub Action for deploying ingresses.
 
 inputs:
-  ACR_REGISTRY:
-    description: The Azure Container Registry.
+  ECR_REGISTRY:
+    description: The Amazon Elastic Container Registry.
     required: true
-  ACR_PULL_PASSWORD:
-    description: The password for the Azure Container Registry.
+  ECR_PULL_PASSWORD:
+    description: The password for the Amazon Elastic Container Registry.
     required: true
-  ACR_PULL_USERNAME:
-    description: The username for the Azure Container Registry.
+  ECR_PULL_USERNAME:
+    description: The username for the Amazon Elastic Container Registry.
     required: true
   ARTIFACT_NAME:
     description: The name of the artifact.
@@ -109,7 +109,7 @@ runs:
     - name: Helm Install Fineract Frontend
       run: |
         export HELM_EXPERIMENTAL_OCI=1
-        echo "${{ inputs.ACR_PULL_PASSWORD }}" | helm registry login ${{ inputs.ACR_REGISTRY }} --username "${{ inputs.ACR_PULL_USERNAME }}" --password-stdin
+        echo "${{ inputs.ECR_PULL_PASSWORD }}" | helm registry login ${{ inputs.ECR_REGISTRY }} --username "${{ inputs.ECR_PULL_USERNAME }}" --password-stdin
 
         helm upgrade --install \
           "${{ inputs.RELEASE_NAME }}" \
@@ -117,5 +117,5 @@ runs:
           --values "${{ github.workspace }}/${{ inputs.ARTIFACT_NAME }}/values.yaml" \
           --namespace "${{ inputs.NAMESPACE }}" \
           --debug --wait \
-          oci://${{ inputs.ACR_REGISTRY }}/helm/fineract-frontend
+          oci://${{ inputs.ECR_REGISTRY }}/helm/fineract-frontend
       shell: bash

--- a/.github/actions/helm_fineract_frontend/action.yml
+++ b/.github/actions/helm_fineract_frontend/action.yml
@@ -5,12 +5,6 @@ inputs:
   ECR_REGISTRY:
     description: The Amazon Elastic Container Registry.
     required: true
-  ECR_PULL_PASSWORD:
-    description: The password for the Amazon Elastic Container Registry.
-    required: true
-  ECR_PULL_USERNAME:
-    description: The username for the Amazon Elastic Container Registry.
-    required: true
   ARTIFACT_NAME:
     description: The name of the artifact.
     required: true
@@ -72,6 +66,7 @@ inputs:
     description: The URL of the APM server.
   APM_ACTIVE:
     description: Whether APM is active or not.
+    type: boolean
     default: true
 
 runs:
@@ -108,9 +103,6 @@ runs:
 
     - name: Helm Install Fineract Frontend
       run: |
-        export HELM_EXPERIMENTAL_OCI=1
-        echo "${{ inputs.ECR_PULL_PASSWORD }}" | helm registry login ${{ inputs.ECR_REGISTRY }} --username "${{ inputs.ECR_PULL_USERNAME }}" --password-stdin
-
         helm upgrade --install \
           "${{ inputs.RELEASE_NAME }}" \
           --values "${{ github.workspace }}/fineract-values.yaml" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
   Build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -63,21 +66,25 @@ jobs:
       - name: Install Node Packages
         run: npm install
 
-      - name: Login to Azure registry
-        uses: docker/login-action@v3.3.0
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         if: ${{ env.SHOULD_PUBLISH == 'true'}}
         with:
-          registry: ${{ vars.ACR_REGISTRY }}
-          username: ${{ vars.ACR_PULL_USERNAME }}
-          password: ${{ secrets.ACR_PULL_PASSWORD }}
+          role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        if: ${{ env.SHOULD_PUBLISH == 'true'}}
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Docker Build & Push
         uses: docker/Build-push-action@v6.13.0
         with:
           push: ${{ env.SHOULD_PUBLISH == 'true'}}
           tags: |
-            ${{ vars.ACR_REGISTRY }}/oneacrefund/fineract-frontend-v2:${{ steps.set-env.outputs.IMAGE_TAGS }}
-            ${{ vars.ACR_REGISTRY }}/oneacrefund/fineract-frontend-v2:latest
+            ${{ steps.login-ecr.outputs.registry }}/oneacrefund/fineract-frontend-v2:${{ steps.set-env.outputs.IMAGE_TAGS }}
+            ${{ steps.login-ecr.outputs.registry }}/oneacrefund/fineract-frontend-v2:latest
           context: ${{ github.workspace }}
 
       - name: Use latest image tag
@@ -128,6 +135,9 @@ jobs:
     needs: [Build, QualityCheck]
     environment:
       name: Integration
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -142,13 +152,26 @@ jobs:
           K8S_URL: "${{ secrets.K8S_TEST_URL }}"
           K8S_SECRET: "${{ secrets.K8S_TEST_DEFAULT }}"
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Generate ECR pull token
+        id: ecr-token
+        run: |
+          ECR_PASSWORD=$(aws ecr get-login-password --region ${{ vars.AWS_REGION }})
+          echo "::add-mask::$ECR_PASSWORD"
+          echo "ECR_PASSWORD=$ECR_PASSWORD" >> $GITHUB_OUTPUT
+
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
-          ACR_REGISTRY: "${{ vars.ACR_REGISTRY }}"
-          ACR_PULL_PASSWORD: "${{ secrets.ACR_PULL_PASSWORD }}"
-          ACR_PULL_USERNAME: "${{ vars.ACR_PULL_USERNAME }}"
+          ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
+          ECR_PULL_PASSWORD: "${{ steps.ecr-token.outputs.ECR_PASSWORD }}"
+          ECR_PULL_USERNAME: "AWS"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -176,6 +199,9 @@ jobs:
     if: github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/develop' || contains(github.event.ref, 'refs/heads/hotfix/') || contains(github.event.ref, 'refs/heads/release/')
     environment:
       name: QA
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -190,13 +216,26 @@ jobs:
           K8S_URL: "${{ secrets.K8S_QA_URL }}"
           K8S_SECRET: "${{ secrets.K8S_QA_DEFAULT }}"
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Generate ECR pull token
+        id: ecr-token
+        run: |
+          ECR_PASSWORD=$(aws ecr get-login-password --region ${{ vars.AWS_REGION }})
+          echo "::add-mask::$ECR_PASSWORD"
+          echo "ECR_PASSWORD=$ECR_PASSWORD" >> $GITHUB_OUTPUT
+
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
-          ACR_REGISTRY: "${{ vars.ACR_REGISTRY }}"
-          ACR_PULL_PASSWORD: "${{ secrets.ACR_PULL_PASSWORD }}"
-          ACR_PULL_USERNAME: "${{ vars.ACR_PULL_USERNAME }}"
+          ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
+          ECR_PULL_PASSWORD: "${{ steps.ecr-token.outputs.ECR_PASSWORD }}"
+          ECR_PULL_USERNAME: "AWS"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -224,6 +263,9 @@ jobs:
     needs: [Build, QualityCheck]
     environment:
       name: UAT
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -238,13 +280,26 @@ jobs:
           K8S_URL: "${{ secrets.K8S_UAT_URL }}"
           K8S_SECRET: "${{ secrets.K8S_UAT_DEFAULT }}"
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Generate ECR pull token
+        id: ecr-token
+        run: |
+          ECR_PASSWORD=$(aws ecr get-login-password --region ${{ vars.AWS_REGION }})
+          echo "::add-mask::$ECR_PASSWORD"
+          echo "ECR_PASSWORD=$ECR_PASSWORD" >> $GITHUB_OUTPUT
+
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
-          ACR_REGISTRY: "${{ vars.ACR_REGISTRY }}"
-          ACR_PULL_PASSWORD: "${{ secrets.ACR_PULL_PASSWORD }}"
-          ACR_PULL_USERNAME: "${{ vars.ACR_PULL_USERNAME }}"
+          ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
+          ECR_PULL_PASSWORD: "${{ steps.ecr-token.outputs.ECR_PASSWORD }}"
+          ECR_PULL_USERNAME: "AWS"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -272,6 +327,9 @@ jobs:
     if: github.event.ref == 'refs/heads/main' || contains(github.event.ref, 'refs/heads/hotfix/') || contains(github.event.ref, 'refs/heads/release/')
     environment:
       name: Production
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -286,13 +344,26 @@ jobs:
           K8S_URL: "${{ secrets.K8S_PROD_URL }}"
           K8S_SECRET: "${{ secrets.K8S_PROD_DEFAULT }}"
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Generate ECR pull token
+        id: ecr-token
+        run: |
+          ECR_PASSWORD=$(aws ecr get-login-password --region ${{ vars.AWS_REGION }})
+          echo "::add-mask::$ECR_PASSWORD"
+          echo "ECR_PASSWORD=$ECR_PASSWORD" >> $GITHUB_OUTPUT
+
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
-          ACR_REGISTRY: "${{ vars.ACR_REGISTRY }}"
-          ACR_PULL_PASSWORD: "${{ secrets.ACR_PULL_PASSWORD }}"
-          ACR_PULL_USERNAME: "${{ vars.ACR_PULL_USERNAME }}"
+          ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
+          ECR_PULL_PASSWORD: "${{ steps.ecr-token.outputs.ECR_PASSWORD }}"
+          ECR_PULL_USERNAME: "AWS"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
           show-progress: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 18
 
@@ -102,14 +102,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
           show-progress: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 18
 
@@ -140,7 +140,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Helm
         uses: one-acre-fund/oaf-actions/helm_setup@1.0.0
@@ -158,20 +158,11 @@ jobs:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Generate ECR pull token
-        id: ecr-token
-        run: |
-          ECR_PASSWORD=$(aws ecr get-login-password --region ${{ vars.AWS_REGION }})
-          echo "::add-mask::$ECR_PASSWORD"
-          echo "ECR_PASSWORD=$ECR_PASSWORD" >> $GITHUB_OUTPUT
-
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
           ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
-          ECR_PULL_PASSWORD: "${{ steps.ecr-token.outputs.ECR_PASSWORD }}"
-          ECR_PULL_USERNAME: "AWS"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -204,7 +195,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Helm
         uses: one-acre-fund/oaf-actions/helm_setup@1.0.0
@@ -222,20 +213,11 @@ jobs:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Generate ECR pull token
-        id: ecr-token
-        run: |
-          ECR_PASSWORD=$(aws ecr get-login-password --region ${{ vars.AWS_REGION }})
-          echo "::add-mask::$ECR_PASSWORD"
-          echo "ECR_PASSWORD=$ECR_PASSWORD" >> $GITHUB_OUTPUT
-
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
           ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
-          ECR_PULL_PASSWORD: "${{ steps.ecr-token.outputs.ECR_PASSWORD }}"
-          ECR_PULL_USERNAME: "AWS"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -268,7 +250,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Helm
         uses: one-acre-fund/oaf-actions/helm_setup@1.0.0
@@ -286,20 +268,11 @@ jobs:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Generate ECR pull token
-        id: ecr-token
-        run: |
-          ECR_PASSWORD=$(aws ecr get-login-password --region ${{ vars.AWS_REGION }})
-          echo "::add-mask::$ECR_PASSWORD"
-          echo "ECR_PASSWORD=$ECR_PASSWORD" >> $GITHUB_OUTPUT
-
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
           ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
-          ECR_PULL_PASSWORD: "${{ steps.ecr-token.outputs.ECR_PASSWORD }}"
-          ECR_PULL_USERNAME: "AWS"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -332,7 +305,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Helm
         uses: one-acre-fund/oaf-actions/helm_setup@1.0.0
@@ -350,20 +323,11 @@ jobs:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Generate ECR pull token
-        id: ecr-token
-        run: |
-          ECR_PASSWORD=$(aws ecr get-login-password --region ${{ vars.AWS_REGION }})
-          echo "::add-mask::$ECR_PASSWORD"
-          echo "ECR_PASSWORD=$ECR_PASSWORD" >> $GITHUB_OUTPUT
-
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
           ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
-          ECR_PULL_PASSWORD: "${{ steps.ecr-token.outputs.ECR_PASSWORD }}"
-          ECR_PULL_USERNAME: "AWS"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ env:
   SHOULD_PUBLISH: ${{ github.ref  == 'refs/heads/master' ||  github.ref == 'refs/heads/develop' || startsWith(github.ref , 'refs/heads/release') }}
   IS_RELEASE: ${{ github.ref  == 'refs/heads/master' }}
   ARTIFACT_NAME: fineract-frontend-v2
+  AWS_REGION: eu-west-1
 
 jobs:
   Build:
@@ -67,16 +68,14 @@ jobs:
         run: npm install
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        if: ${{ env.SHOULD_PUBLISH == 'true'}}
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: Login to Amazon ECR
+      - name: Login to AWS ECR
         id: login-ecr
-        if: ${{ env.SHOULD_PUBLISH == 'true'}}
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@v2.1.5
 
       - name: Docker Build & Push
         uses: docker/Build-push-action@v6.13.0
@@ -153,16 +152,20 @@ jobs:
           K8S_SECRET: "${{ secrets.K8S_TEST_DEFAULT }}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.5
 
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
-          ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
+          ECR_REGISTRY: "${{ steps.login-ecr.outputs.registry }}"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -208,16 +211,20 @@ jobs:
           K8S_SECRET: "${{ secrets.K8S_QA_DEFAULT }}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.5
 
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
-          ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
+          ECR_REGISTRY: "${{ steps.login-ecr.outputs.registry }}"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -263,16 +270,20 @@ jobs:
           K8S_SECRET: "${{ secrets.K8S_UAT_DEFAULT }}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.5
 
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
-          ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
+          ECR_REGISTRY: "${{ steps.login-ecr.outputs.registry }}"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"
@@ -318,16 +329,20 @@ jobs:
           K8S_SECRET: "${{ secrets.K8S_PROD_DEFAULT }}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ vars.ECR_REGISTRY_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.5
 
       - name: Deploy using Helm
         uses: "./.github/actions/helm_fineract_frontend"
         with:
           NAMESPACE: "${{ vars.NAMESPACE }}"
-          ECR_REGISTRY: "${{ vars.ECR_REGISTRY }}"
+          ECR_REGISTRY: "${{ steps.login-ecr.outputs.registry }}"
           ARTIFACT_NAME: "${{ env.ARTIFACT_NAME }}"
           REPLICAS: "${{ vars.REPLICAS }}"
           RELEASE_NAME: "${{ vars.RELEASE_NAME }}"

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ Thumbs.db
 # Sentry Config File
 .sentryclirc
 package-lock.json
+.claude/settings.local.json

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -1,5 +1,5 @@
 image:
   # Fineract frontend v2 image name
-  name: "oaftech.azurecr.io/oneacrefund/fineract-frontend-v2"
+  name: "952409747009.dkr.ecr.eu-west-1.amazonaws.com/oneacrefund/fineract-frontend-v2"
   # Fineract Frontend v2 image tag placeholder that will be replaced in Azure pipeline task
   tag: "oneacrefund"


### PR DESCRIPTION
This pull request migrates the CI/CD pipeline for the Fineract Frontend from using Azure Container Registry (ACR) to Amazon Elastic Container Registry (ECR), updating both the reusable GitHub Action and the main workflow to support AWS authentication and image deployment. It also updates several GitHub Actions to their latest versions and ensures all environments (Integration, QA, UAT, Production) use the new ECR-based deployment flow.

**Migration from Azure to AWS:**

* The pipeline now authenticates with AWS using OIDC and deploys Docker images to ECR instead of ACR throughout all environments (`.github/workflows/build.yml`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L66-R86) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R154-R168) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R213-R227) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R272-R286) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R331-R345)
* The custom Helm deployment GitHub Action was updated to use `ECR_REGISTRY` instead of `ACR_REGISTRY`, and all Azure-specific inputs were removed (`.github/actions/helm_fineract_frontend/action.yml`). [[1]](diffhunk://#diff-9022a2b85a14bf0e116657f211ecc1032b00254034273828ec4ce2c79ce9435aL5-R6) [[2]](diffhunk://#diff-9022a2b85a14bf0e116657f211ecc1032b00254034273828ec4ce2c79ce9435aL111-R112)

**Authentication and Permissions:**

* OIDC-based AWS authentication is configured for each environment, granting the workflow permissions to assume the necessary IAM role for ECR access (`.github/workflows/build.yml`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R22-R40) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R137-R142) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R196-R201) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R255-R260) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R314-R319)

**Action and Dependency Updates:**

* Updated `actions/checkout` and `actions/setup-node` to their latest major versions for improved performance and security (`.github/workflows/build.yml`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R22-R40) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L98-R111) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R137-R142) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R196-R201) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R255-R260) [[6]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R314-R319)

**Helm Deployment Improvements:**

* The Helm deployment step now consistently pulls images from ECR using the dynamically authenticated registry output, ensuring images are deployed from the correct AWS account (`.github/workflows/build.yml`, `.github/actions/helm_fineract_frontend/action.yml`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L66-R86) [[2]](diffhunk://#diff-9022a2b85a14bf0e116657f211ecc1032b00254034273828ec4ce2c79ce9435aL111-R112)

**Other Enhancements:**

* Minor improvements to input defaults and requirements in the custom Helm deployment action (`.github/actions/helm_fineract_frontend/action.yml`).