### PR TITLE
FOX-212: add 'in scope' field to loan product

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,8 @@
 
 ## Version 1.4.11 - Community 1.0.0
     * Savings Accounts & Products
-        * [FOX-212] - Add in_scope field to LoanProduct entity to allow isolation of loan products in scope for field operations for summary calculations
-        
+        * [FOX-212] - Add inScope field to LoanProduct entity to allow isolation of loan products in scope for field operations for summary calculations
+
 ## Version 1.4.10 - Community 1.0.0
     * Loans & Payments
         * [CP-4057] - Improve Rahisi Model UI to show more details and make it more user friendly

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 1.4.11 - Community 1.0.0
+    * Savings Accounts & Products
+        * [FOX-212] - Add in_scope field to LoanProduct entity to allow isolation of loan products in scope for field operations for summary calculations
+        
 ## Version 1.4.10 - Community 1.0.0
     * Loans & Payments
         * [CP-4057] - Improve Rahisi Model UI to show more details and make it more user friendly

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.html
@@ -51,6 +51,7 @@
   <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
     <mat-checkbox fxFlex="48%" labelPosition="before" formControlName="inScope">
       {{ 'labels.oaf.in_scope' | translate }}
+      <fa-icon icon="question-circle" matTooltip="{{ 'labels.oaf.in_scope_tooltip' | translate }}" matTooltipPosition="right"></fa-icon>
     </mat-checkbox>
   </div>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.html
@@ -48,6 +48,12 @@
     </mat-form-field>
   </div>
 
+  <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
+    <mat-checkbox fxFlex="48%" labelPosition="before" formControlName="inScope">
+      {{ 'labels.oaf.in_scope' | translate }}
+    </mat-checkbox>
+  </div>
+
   <div fxLayout="row" class="margin-t" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="2%">
     <button mat-raised-button matStepperPrevious disabled>
       <fa-icon icon="arrow-left"></fa-icon>&nbsp;&nbsp;{{ 'labels.buttons.Previous' | translate }}

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.ts
@@ -46,7 +46,8 @@ export class LoanProductDetailsStepComponent implements OnInit {
       'startDate': this.loanProductsTemplate.startDate && new Date(this.loanProductsTemplate.startDate),
       'closeDate': this.loanProductsTemplate.closeDate && new Date(this.loanProductsTemplate.closeDate),
       'includeInBorrowerCycle': this.loanProductsTemplate.includeInBorrowerCycle,
-      'loanTypeId': this.loanProductsTemplate.loanType?.id
+      'loanTypeId': this.loanProductsTemplate.loanType?.id,
+      'inScope': this.loanProductsTemplate.inScope || false
     });
   }
 
@@ -58,7 +59,8 @@ export class LoanProductDetailsStepComponent implements OnInit {
       'startDate': [''],
       'closeDate': [''],
       'includeInBorrowerCycle': [false],
-      'loanTypeId': ['', Validators.required]
+      'loanTypeId': ['', Validators.required],
+      'inScope': [true]
     });
   }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.ts
@@ -47,7 +47,7 @@ export class LoanProductDetailsStepComponent implements OnInit {
       'closeDate': this.loanProductsTemplate.closeDate && new Date(this.loanProductsTemplate.closeDate),
       'includeInBorrowerCycle': this.loanProductsTemplate.includeInBorrowerCycle,
       'loanTypeId': this.loanProductsTemplate.loanType?.id,
-      'inScope': this.loanProductsTemplate.inScope || false
+      'inScope': this.loanProductsTemplate.inScope ?? true
     });
   }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
@@ -39,6 +39,11 @@
     <span fxFlex="60%">{{ loanProduct.description }}</span>
   </div>
 
+  <div fxFlexFill>
+    <span fxFlex="40%">{{ 'labels.oaf.in_scope' | translate }}</span>
+    <span fxFlex="60%">{{ loanProduct.inScope ? ('labels.boolean.Yes' | translate) : ('labels.boolean.No' | translate) }}</span>
+  </div>
+
   <h3 class="mat-h3" fxFlexFill>{{ 'labels.inputs.Currency' | translate }}</h3>
 
   <mat-divider fxFlexFill></mat-divider>

--- a/src/app/products/loan-products/view-loan-product/view-loan-product.component.html
+++ b/src/app/products/loan-products/view-loan-product/view-loan-product.component.html
@@ -51,6 +51,11 @@
           <span fxFlex="60%">{{ loanProduct.closeDate | dateFormat }}</span>
         </div>
 
+        <div fxFlexFill>
+          <span fxFlex="40%">{{ 'labels.oaf.in_scope' | translate }}</span>
+          <span fxFlex="60%">{{ loanProduct.inScope ? ('labels.boolean.Yes' | translate) : ('labels.boolean.No' | translate) }}</span>
+        </div>
+
         <div fxFlexFill *ngIf="loanProduct.description">
           <span fxFlex="40%">{{ 'labels.inputs.Description' | translate }}</span>
           <span fxFlex="60%">{{ loanProduct.description }}</span>

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -322,6 +322,7 @@
       "Short Name": "Short Name",
       "Loan Type": "Loan Type",
       "Product Name": "Product Name",
+      "in_scope": "In Scope",
       "Is Equal Amortization": "Is Equal Amortization",
       "OverdueCharges": "Overdue Charges",
       "Qualification Rules": "Qualification Rules",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -323,6 +323,7 @@
       "Loan Type": "Loan Type",
       "Product Name": "Product Name",
       "in_scope": "In Scope",
+      "in_scope_tooltip": "Indicates whether this loan product is currently active and available for use within the organisation's operational scope.",
       "Is Equal Amortization": "Is Equal Amortization",
       "OverdueCharges": "Overdue Charges",
       "Qualification Rules": "Qualification Rules",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -321,7 +321,7 @@
       "Short Name": "Nom court",
       "Loan Type": "Type de prêt",
       "Product Name": "Nom du produit",
-      "in_scope": "Dans la portée",
+      "in_scope": "Dans le périmètre",
       "Is Equal Amortization": "Amortissement égal",
       "Qualification Rules": "Règles de qualification",
       "Previously not taken credit": "Crédit non pris précédemment",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -321,6 +321,7 @@
       "Short Name": "Nom court",
       "Loan Type": "Type de prêt",
       "Product Name": "Nom du produit",
+      "in_scope": "Dans la portée",
       "Is Equal Amortization": "Amortissement égal",
       "Qualification Rules": "Règles de qualification",
       "Previously not taken credit": "Crédit non pris précédemment",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -322,6 +322,7 @@
       "Loan Type": "Type de prêt",
       "Product Name": "Nom du produit",
       "in_scope": "Dans le périmètre",
+      "in_scope_tooltip": "Indique si ce produit de prêt est actuellement actif et disponible dans le périmètre opérationnel de l'organisation.",
       "Is Equal Amortization": "Amortissement égal",
       "Qualification Rules": "Règles de qualification",
       "Previously not taken credit": "Crédit non pris précédemment",

--- a/src/assets/translations/sw-KE.json
+++ b/src/assets/translations/sw-KE.json
@@ -323,6 +323,7 @@
       "Loan Type": "Aina ya Mkopo",
       "Product Name": "Jina la Bidhaa",
       "in_scope": "Inatumika",
+      "in_scope_tooltip": "Inaonyesha kama bidhaa hii ya mkopo iko katika matumizi na inapatikana ndani ya upeo wa uendeshaji wa shirika.",
       "Is Equal Amortization": "Ni Amortization Sawa",
       "OverdueCharges": "Malipo ya Kuchelewa",
       "Qualification Rules": "Sheria za Utauzi",

--- a/src/assets/translations/sw-KE.json
+++ b/src/assets/translations/sw-KE.json
@@ -322,6 +322,7 @@
       "Short Name": "Jina Fupi",
       "Loan Type": "Aina ya Mkopo",
       "Product Name": "Jina la Bidhaa",
+      "in_scope": "Inatumika",
       "Is Equal Amortization": "Ni Amortization Sawa",
       "OverdueCharges": "Malipo ya Kuchelewa",
       "Qualification Rules": "Sheria za Utauzi",


### PR DESCRIPTION

## Description
This change adds an "In Scope" (`inScope`) field to loan products, allowing users to specify whether a loan product should be included in field operations and summary calculations. The change is reflected in the UI for creating, previewing, and viewing loan products.

## Screenshots
<img width="1210" height="522" alt="image" src="https://github.com/user-attachments/assets/710f6355-466e-48ce-9e29-ec3171bee7ff" />

<img width="1259" height="467" alt="image" src="https://github.com/user-attachments/assets/6d081de2-dcc2-4fde-a8ef-00200ddd92da" />

<img width="1202" height="502" alt="image" src="https://github.com/user-attachments/assets/88936144-dab3-4288-8611-d7cf107ee2e5" />

<img width="658" height="488" alt="image" src="https://github.com/user-attachments/assets/f16eed84-8c96-471a-ab21-609d70898f9b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "In Scope" field to loan products, displayed as a checkbox in the product details form and shown in product preview and view pages.

* **Documentation**
  * Updated release notes for version 1.4.11 - Community 1.0.0.

* **Internationalization**
  * Added "In Scope" field translations in English, French, and Swahili.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->