### PR TITLE
HQX-117 Add standardized configurable kyc failure reasons

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@
 ## Version 1.4.11 - Community 1.0.0
     * Savings Accounts & Products
         * [FOX-212] - Add inScope field to LoanProduct entity to allow isolation of loan products in scope for field operations for summary calculations
+    * Clients & Groups
+        * [HQX-117] - Add standardized configurable kyc failure reasons 
 
 ## Version 1.4.10 - Community 1.0.0
     * Loans & Payments

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,16 +1,15 @@
 # Release Notes
 
-## Version 1.4.12 - Community 1.0.0
-    * Clients & Groups
-        * [HQX-120] - Display client status transitions
-
 ## Version 1.4.11 - Community 1.0.0
+
     * Savings Accounts & Products
         * [FOX-212] - Add inScope field to LoanProduct entity to allow isolation of loan products in scope for field operations for summary calculations
     * Clients & Groups
-        * [HQX-117] - Add standardized configurable kyc failure reasons 
+        * [HQX-117] - Add standardized configurable kyc failure reasons
+        * [HQX-120] - Display client status transitions
 
 ## Version 1.4.10 - Community 1.0.0
+
     * Loans & Payments
         * [CP-4057] - Improve Rahisi Model UI to show more details and make it more user friendly
     * System
@@ -18,14 +17,16 @@
     * Savings Accounts & Products
         * [HQX-235] - Ability to download savings transaction template without selecting an office
     * Clients & Groups
-        * [HQX-72] - Provide Visibility on Group Leader History 
+        * [HQX-72] - Provide Visibility on Group Leader History
         * [HQX-270] - Ability to track historical group removal for audit & analysis
 
 ## Version 1.4.9.1 - Community 1.0.0
+
     * Clients
         * * [CP-4095] - Payment Provider External service: Introduce support of date format for a payment provider
 
 ## Version 1.4.9 - Community 1.0.0
+
     * Bulk Uploads
         * [CP-4042] - Add bulk upload to remove clients from groups
     * Loans & Payments
@@ -33,17 +34,19 @@
         * [CP-4065] - Add Delivery Details Tab and Fetch Button in Loan Management
 
 ## Version 1.4.8.1 - Community 1.0.0
+
     * Bulk Uploads
         * [CP-4085] - Client Transfer: Rename client group transfer to client transfer and enable download template button only if the office is selected
 
 ## Version 1.4.8 - Community 1.0.0
+
     * Bulk Downloads
         * [CP-4041] - Enable bulk download for unqualified and non picker clients for a loan product
     * Bulk Uploads
         * [CP-4015] - Add bulk upload to move groups to different sites
 
-
 ## Version 1.4.7.1 - Community 1.0.0
+
     * Clients
         * [CP-4059] -  Client activation: allow activation of clients with inactive substatuses
 
@@ -59,26 +62,32 @@
        * [CP-4058] - Hide dynamic downpayment
 
 ## Version 1.4.6 - Community 1.0.0
+
     * Configurations
         * [CP-3666] - Refactor Template Configuration with HTML Support Per Country
     * Navigation Bar
         * [CP-4004] - Disabling the notification tray for now since it's not being consumed
     * Clients
         * [CP-3711] - Enable bulk upload of existing farmers to existing groups
-           
+
+
 ## Version 1.4.4 - Community 1.0.0
+
     * Clients
         * [CP-3935] - Add time a client landed in the checker inbox
         * [CP-3971] - Rename phone number field in UI to Paid By in transaction history
         * [CP-3536] - Fix Cannot read properties of undefined errors reported by Sentry
 
 ## Version 1.4.3 - Community 1.0.0
+
     * Clients
         * [CP-3882] - Add display for gender and KYC Failed fields in client profile
     * External Services
         * [CP-3932] - Revamp the notification external service UI
+
 ## Version 1.4.2 - Community 1.0.0
-    * Maker Checker 
+
+    * Maker Checker
         * [CP-3873] - KYC Maker Checker UI Improvements
         * [CP-3911] - Apply KYC backend changes to align with the updated requirements.
         * [CP-3927] - Enable search by client name and order by date on Failed KYC tab.
@@ -98,7 +107,7 @@
     * Tranlations
         * [CP-3741] - Fix Translations Related to Angular Material Pagination and Breadcrumbs
         * [CP-3788] - Fix other translation reported issues
-        
+
     * Maker Checker
         * [CP-3723] - Improve user experience for the maker
 

--- a/src/app/tasks/check-inbox-dialog/request-info-dialog/request-info-dialog.component.html
+++ b/src/app/tasks/check-inbox-dialog/request-info-dialog/request-info-dialog.component.html
@@ -2,9 +2,17 @@
 <mat-dialog-content>
   <form [formGroup]="form">
 
-    <mat-form-field appearance="fill" class="w-full">
+    <mat-form-field>
       <mat-label>{{ 'labels.inputs.Reason' | translate }}</mat-label>
-      <textarea matInput rows="4" formControlName="kycRejectionNotes"></textarea>
+      <mat-select required formControlName="kycRejectionNotes" multiple>
+        <mat-option *ngFor="let note of kycFieldRejectionNotes" [value]="note">
+          {{ note }}
+        </mat-option>
+      </mat-select>
+      <mat-error *ngIf="form.controls.kycRejectionNotes.hasError('required')">
+        {{ 'labels.inputs.Reason' | translate }}
+        <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field>

--- a/src/app/tasks/check-inbox-dialog/request-info-dialog/request-info-dialog.component.ts
+++ b/src/app/tasks/check-inbox-dialog/request-info-dialog/request-info-dialog.component.ts
@@ -12,7 +12,7 @@ import { environment } from 'environments/environment';
 export class RequestInfoDialogComponent implements OnInit {
   form: FormGroup;
   kycFields: any = [];
-  kycFieldRejectionNotes: any = [];
+  kycFieldRejectionNotes: string[] = [];
   isRequestSubmitButtonDisabled = false
 
   constructor(

--- a/src/app/tasks/check-inbox-dialog/request-info-dialog/request-info-dialog.component.ts
+++ b/src/app/tasks/check-inbox-dialog/request-info-dialog/request-info-dialog.component.ts
@@ -12,6 +12,7 @@ import { environment } from 'environments/environment';
 export class RequestInfoDialogComponent implements OnInit {
   form: FormGroup;
   kycFields: any = [];
+  kycFieldRejectionNotes: any = [];
   isRequestSubmitButtonDisabled = false
 
   constructor(
@@ -43,6 +44,7 @@ export class RequestInfoDialogComponent implements OnInit {
         } else {
           this.kycFields = [];
         }
+        this.kycFieldRejectionNotes = response.kycRejectionNotes;
       },
       error: (err) => {
         this.alertService.alert({
@@ -70,6 +72,7 @@ export class RequestInfoDialogComponent implements OnInit {
 
   submit() {
     const data = { ...this.form.value };
+    console.log('Submitting data:', data);
      this.taskService.rejectClientVerification(this.data?.client?.id, data).subscribe({
       next: () => {
         this.dialogRef.close(this.form.value);

--- a/src/app/tasks/check-inbox-dialog/request-info-dialog/request-info-dialog.component.ts
+++ b/src/app/tasks/check-inbox-dialog/request-info-dialog/request-info-dialog.component.ts
@@ -23,8 +23,8 @@ export class RequestInfoDialogComponent implements OnInit {
     private readonly alertService: AlertService,
   ) {
     this.form = this.fb.group({
-      failedKycFields: ['', Validators.required],
-      kycRejectionNotes: ['', Validators.required]
+      failedKycFields: [[], Validators.required],
+      kycRejectionNotes: [[], Validators.required]
     });
   }
 
@@ -44,7 +44,7 @@ export class RequestInfoDialogComponent implements OnInit {
         } else {
           this.kycFields = [];
         }
-        this.kycFieldRejectionNotes = response.kycRejectionNotes;
+        this.kycFieldRejectionNotes = Array.isArray(response?.kycRejectionNotes) ? response.kycRejectionNotes : [];
       },
       error: (err) => {
         this.alertService.alert({
@@ -72,7 +72,6 @@ export class RequestInfoDialogComponent implements OnInit {
 
   submit() {
     const data = { ...this.form.value };
-    console.log('Submitting data:', data);
      this.taskService.rejectClientVerification(this.data?.client?.id, data).subscribe({
       next: () => {
         this.dialogRef.close(this.form.value);


### PR DESCRIPTION
## Description
- Add standardized configurable Client KYC failure reasons

## Changes Included in PR
- [HQX-117 - Standardize Client KYC failure reasons](https://oneacrefund.atlassian.net/browse/HQX-117)

## Screenshots, if any
<img width="825" height="785" alt="Screenshot 2026-06-25 at 12 04 12" src="https://github.com/user-attachments/assets/4204f57a-aa7e-4996-90ff-2a8cb5f78a21" />

<img width="867" height="784" alt="Screenshot 2026-06-25 at 12 03 47" src="https://github.com/user-attachments/assets/179734ad-16cc-4d0d-9864-da723f54f3df" />

.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized, configurable KYC failure reasons for the Clients & Groups area.
  * Display client status transitions in the Clients & Groups experience.
* **Bug Fixes**
  * Replaced the free-text KYC rejection reason with a required multi-select, including validation feedback when no reason is chosen.
  * Improved restoration of previously saved rejection reasons when reopening the verification review dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->