### PR TITLE
HQX-120: Display client status transitions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 1.4.12 - Community 1.0.0
+    * Clients & Groups
+        * [HQX-120] - Display client status transitions
+
 ## Version 1.4.11 - Community 1.0.0
     * Savings Accounts & Products
         * [FOX-212] - Add inScope field to LoanProduct entity to allow isolation of loan products in scope for field operations for summary calculations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mifosx-web-app",
-  "version": "1.4.10",
+  "version": "1.4.12",
   "description": "MifosX Web App is the default web application built on top of the Fineract platform for the Mifos user community leveraging the popular Angular framework.",
   "keywords": [
     "mifos",

--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -19,6 +19,7 @@ import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component'
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
 import { AddressTabComponent } from './clients-view/address-tab/address-tab.component';
+import { StatusTransitionsTabComponent } from './clients-view/status-transitions-tab/status-transitions-tab.component';
 import { ClientActionsComponent } from './clients-view/client-actions/client-actions.component';
 import { ViewChargeComponent } from './clients-view/charges/view-charge/view-charge.component';
 import { ClientPayChargesComponent } from './clients-view/charges/client-pay-charges/client-pay-charges.component';
@@ -42,6 +43,7 @@ import { ClientDatatableResolver } from './common-resolvers/client-datatable.res
 import { ClientIdentifierTemplateResolver } from './common-resolvers/client-identifier-template.resolver';
 import { ClientAddressFieldConfigurationResolver } from './common-resolvers/client-address-fieldconfiguration.resolver';
 import { ClientAddressTemplateResolver } from './common-resolvers/client-address-template.resolver';
+import { ClientStatusTransitionsResolver } from './common-resolvers/client-status-transitions.resolver';
 import { ChargesOverviewComponent } from './clients-view/charges/charges-overview/charges-overview.component';
 import { ClientChargeOverviewResolver } from './clients-view/charges/charges-overview/charge-overview.resolver';
 import { ClientActionsResolver } from './common-resolvers/client-actions.resolver';
@@ -174,6 +176,18 @@ const routes: Routes = [
               data: { title: extract('labels.heading.Notes'), breadcrumb: 'Notes', routeParamBreadcrumb: false },
               resolve: {
                 clientNotes: ClientNotesResolver,
+              },
+            },
+            {
+              path: 'status-transitions',
+              component: StatusTransitionsTabComponent,
+              data: {
+                title: extract('labels.heading.StatusTransitions'),
+                breadcrumb: 'Status Transitions',
+                routeParamBreadcrumb: false,
+              },
+              resolve: {
+                clientStatusTransitions: ClientStatusTransitionsResolver,
               },
             },
             {
@@ -310,6 +324,7 @@ const routes: Routes = [
     ClientIdentifierTemplateResolver,
     ClientAddressFieldConfigurationResolver,
     ClientAddressTemplateResolver,
+    ClientStatusTransitionsResolver,
     ClientChargeOverviewResolver,
     ClientActionsResolver,
     ClientChargeViewResolver,

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -360,6 +360,15 @@
       >
         {{ 'labels.inputs.Notes' | translate }}
       </a>
+      <a
+        mat-tab-link
+        [routerLink]="['./status-transitions']"
+        routerLinkActive
+        #statusTransitions="routerLinkActive"
+        [active]="statusTransitions.isActive"
+      >
+        {{ 'labels.inputs.StatusTransitions' | translate }}
+      </a>
       <!--  <ng-container *ngFor="let clientDatatable of clientDatatables">
         <a mat-tab-link [routerLink]="['./datatables',clientDatatable.registeredTableName]"
           routerLinkActive #datatable="routerLinkActive" [active]="datatable.isActive" *mifosxHasPermission="'READ_' + clientDatatable.registeredTableName">

--- a/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.html
+++ b/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.html
@@ -13,12 +13,27 @@
     <table mat-table [dataSource]="dataSource" *ngIf="!isLoading && dataSource.data.length > 0">
       <ng-container matColumnDef="transitionType">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.TransitionType' | translate }}</th>
-        <td mat-cell *matCellDef="let row">{{ row.transitionType || '-' }}</td>
+        <td mat-cell *matCellDef="let row">
+          {{
+            row.transitionType === 'STATUS'
+              ? ('labels.transitionType.STATUS' | translate)
+              : row.transitionType === 'SUB_STATUS'
+                ? ('labels.transitionType.SUB_STATUS' | translate)
+                : (row.transitionType || '-')
+          }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="transition">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Transition' | translate }}</th>
-        <td mat-cell *matCellDef="let row">{{ row.previousStatus || '_' }} -> {{ row.newStatus || '_' }}</td>
+        <td mat-cell *matCellDef="let row">
+          <ng-container *ngIf="row.previousStatus; else initialStatus">
+            {{ (row.previousStatus || '-') | uppercase }} -> {{ (row.newStatus || '-') | uppercase }}
+          </ng-container>
+          <ng-template #initialStatus>
+            {{ 'labels.inputs.InitialStatus' | translate }}: {{ (row.newStatus || '-') | uppercase }}
+          </ng-template>
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="statusChangedOn">

--- a/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.html
+++ b/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.html
@@ -1,0 +1,46 @@
+<div class="tab-container mat-typography">
+  <div style="margin-top: 5px">
+    <h2>{{ 'labels.heading.StatusTransitions' | translate }}</h2>
+
+    <div class="loading-container" *ngIf="isLoading" fxLayoutAlign="center center">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+
+    <div *ngIf="!isLoading && dataSource.data.length === 0" class="empty-state" fxLayoutAlign="center center">
+      <p class="mat-body-1">{{ 'labels.text.NoStatusTransitionsFound' | translate }}</p>
+    </div>
+
+    <table mat-table [dataSource]="dataSource" *ngIf="!isLoading && dataSource.data.length > 0">
+      <ng-container matColumnDef="transitionType">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.TransitionType' | translate }}</th>
+        <td mat-cell *matCellDef="let row">{{ row.transitionType || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="transition">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Transition' | translate }}</th>
+        <td mat-cell *matCellDef="let row">{{ row.previousStatus || '_' }} -> {{ row.newStatus || '_' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="statusChangedOn">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.StatusChangedOn' | translate }}</th>
+        <td mat-cell *matCellDef="let row">{{ row.statusChangedOn | dateFormat }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="createdOn">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.TransitionCreatedOn' | translate }}</th>
+        <td mat-cell *matCellDef="let row">{{ row.createdOn | dateFormat }}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    <mat-paginator
+      [length]="totalRecords"
+      [pageSize]="pageSize"
+      [pageSizeOptions]="[10, 25, 50, 100]"
+      (page)="onPageChange($event)"
+      showFirstLastButtons
+    ></mat-paginator>
+  </div>
+</div>

--- a/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.scss
+++ b/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.scss
@@ -1,0 +1,9 @@
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+}
+
+.loading-container,
+.empty-state {
+  min-height: 120px;
+}

--- a/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.ts
+++ b/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.ts
@@ -37,6 +37,8 @@ export class StatusTransitionsTabComponent implements OnInit {
   pageSize = 50;
   /** Loading indicator */
   isLoading = false;
+  /** Flag to track whether resolver data has been applied */
+  resolverDataApplied = false;
 
   /**
    * @param {ActivatedRoute} route Activated Route.
@@ -47,12 +49,13 @@ export class StatusTransitionsTabComponent implements OnInit {
     this.route.data.subscribe((data: { clientStatusTransitions: any }) => {
       if (data.clientStatusTransitions) {
         this.setStatusTransitionsData(data.clientStatusTransitions);
+        this.resolverDataApplied = true;
       }
     });
   }
 
   ngOnInit(): void {
-    if (this.dataSource.data.length === 0) {
+    if (!this.resolverDataApplied) {
       this.fetchStatusTransitions(0, this.pageSize);
     }
   }

--- a/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.ts
+++ b/src/app/clients/clients-view/status-transitions-tab/status-transitions-tab.component.ts
@@ -1,0 +1,101 @@
+/** Angular Imports */
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+/** Angular Material Imports */
+import { MatTableDataSource } from '@angular/material/table';
+
+/** Custom Services */
+import { ClientsService } from '../../clients.service';
+
+/**
+ * Client Status Transitions Tab Component.
+ */
+@Component({
+  selector: 'mifosx-status-transitions-tab',
+  templateUrl: './status-transitions-tab.component.html',
+  styleUrls: ['./status-transitions-tab.component.scss']
+})
+export class StatusTransitionsTabComponent implements OnInit {
+
+  /** Columns to be displayed in status transitions table. */
+  displayedColumns: string[] = [
+    'transitionType',
+    'transition',
+    'statusChangedOn',
+    'createdOn'
+  ];
+
+  /** Data source for status transitions table. */
+  dataSource: MatTableDataSource<any> = new MatTableDataSource<any>([]);
+
+  /** Client ID */
+  clientId: string;
+  /** Total number of filtered records for pagination */
+  totalRecords = 0;
+  /** Current page size */
+  pageSize = 50;
+  /** Loading indicator */
+  isLoading = false;
+
+  /**
+   * @param {ActivatedRoute} route Activated Route.
+   * @param {ClientsService} clientsService Clients service.
+   */
+  constructor(private route: ActivatedRoute, private clientsService: ClientsService) {
+    this.clientId = this.route.parent.snapshot.paramMap.get('clientId');
+    this.route.data.subscribe((data: { clientStatusTransitions: any }) => {
+      if (data.clientStatusTransitions) {
+        this.setStatusTransitionsData(data.clientStatusTransitions);
+      }
+    });
+  }
+
+  ngOnInit(): void {
+    if (this.dataSource.data.length === 0) {
+      this.fetchStatusTransitions(0, this.pageSize);
+    }
+  }
+
+  /**
+   * Sets status transitions data from API response.
+   * @param {any} statusTransitionsData API response data.
+   */
+  private setStatusTransitionsData(statusTransitionsData: any): void {
+    this.dataSource.data = statusTransitionsData?.pageItems || [];
+    this.totalRecords = statusTransitionsData?.totalFilteredRecords || 0;
+  }
+
+  /**
+   * Fetches status transitions for current page.
+   * @param {number} pageIndex Current page index.
+   * @param {number} pageSize Number of records per page.
+   */
+  fetchStatusTransitions(pageIndex: number, pageSize: number): void {
+    this.isLoading = true;
+    const offset = pageIndex * pageSize;
+
+    this.clientsService.getClientStatusTransitions(this.clientId, offset, pageSize, 'statusChangedOn', 'DESC')
+      .subscribe({
+        next: (response: any) => {
+          this.setStatusTransitionsData(response);
+          this.isLoading = false;
+        },
+        error: () => {
+          this.dataSource.data = [];
+          this.totalRecords = 0;
+          this.isLoading = false;
+        }
+      });
+  }
+
+  /**
+   * Called when paginator emits a page event.
+   * @param {any} event Material paginator event.
+   */
+  onPageChange(event: any): void {
+    this.pageSize = event.pageSize;
+    this.fetchStatusTransitions(event.pageIndex, event.pageSize);
+  }
+
+}

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -58,6 +58,7 @@ import { ClientFamilyMemberDialogComponent } from './client-stepper/client-famil
 import { CaptureImageDialogComponent } from './clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component';
 import { CreateSelfServiceUserComponent } from './clients-view/client-actions/create-self-service-user/create-self-service-user.component';
 import { ClientOtpDialogComponent } from './client-otp-dialog/client-otp-dialog.component';
+import { StatusTransitionsTabComponent } from './clients-view/status-transitions-tab/status-transitions-tab.component';
 
 
 /**
@@ -122,7 +123,8 @@ import { ClientOtpDialogComponent } from './client-otp-dialog/client-otp-dialog.
     ClientFamilyMemberDialogComponent,
     CaptureImageDialogComponent,
     CreateSelfServiceUserComponent,
-    ClientOtpDialogComponent
+    ClientOtpDialogComponent,
+    StatusTransitionsTabComponent
   ],
   providers: [ ]
 

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -156,6 +156,22 @@ export class ClientsService {
     return this.http.get(`/clients/${clientId}/charges`, { params: httpParams });
   }
 
+  getClientStatusTransitions(
+    clientId: string,
+    offset: number,
+    limit: number,
+    orderBy: string = 'statusChangedOn',
+    sortOrder: string = 'DESC'
+  ) {
+    const httpParams = new HttpParams()
+      .set('offset', offset.toString())
+      .set('limit', limit.toString())
+      .set('orderBy', orderBy)
+      .set('sortOrder', sortOrder);
+
+    return this.http.get(`/clients/${clientId}/status-transitions`, { params: httpParams });
+  }
+
   getSelectedChargeData(clientId: string, chargeId: string) {
     const httpParams = new HttpParams().set('associations', 'all');
     return this.http.get(`/clients/${clientId}/charges/${chargeId}`, { params: httpParams });

--- a/src/app/clients/common-resolvers/client-status-transitions.resolver.ts
+++ b/src/app/clients/common-resolvers/client-status-transitions.resolver.ts
@@ -1,0 +1,31 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ * Client status transitions resolver.
+ */
+@Injectable()
+export class ClientStatusTransitionsResolver implements Resolve<Object> {
+
+  /**
+   * @param {ClientsService} clientsService Clients service.
+   */
+  constructor(private clientsService: ClientsService) { }
+
+  /**
+   * Returns the Client's status transitions.
+   * @returns {Observable<any>}
+   */
+  resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    const clientId = route.parent.paramMap.get('clientId');
+    return this.clientsService.getClientStatusTransitions(clientId, 0, 50, 'statusChangedOn', 'DESC');
+  }
+
+}

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2643,6 +2643,7 @@
       "StatusTransitions": "Status Transitions",
       "TransitionType": "Transition Type",
       "Transition": "Transition",
+      "InitialStatus": "Initial status",
       "StatusChangedOn": "Status Changed On",
       "TransitionCreatedOn": "Created On",
       "Step Name": "Step Name",
@@ -3074,6 +3075,10 @@
       "Transfer in progress": "Transfer in progress",
       "Transfer on hold": "Transfer on hold",
       "Withdrawn": "Withdrawn"
+    },
+    "transitionType": {
+      "STATUS": "Status",
+      "SUB_STATUS": "Sub Status"
     },
     "dialogContext": {
       "Are you sure you want Unassign Staff": "Are you sure you want Unassign Staff",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1515,7 +1515,8 @@
       "AffectedClients": "Affected Clients",
       "Maker": "Maker",
       "Date": "Date",
-      "MembershipHistory": "Membership History"
+      "MembershipHistory": "Membership History",
+      "StatusTransitions": "Status Transitions"
     },
     "inputs": {
       "accounting": {
@@ -2639,6 +2640,11 @@
       "Starting Date": "Starting Date",
       "State / Province": "State / Province",
       "Status": "Status",
+      "StatusTransitions": "Status Transitions",
+      "TransitionType": "Transition Type",
+      "Transition": "Transition",
+      "StatusChangedOn": "Status Changed On",
+      "TransitionCreatedOn": "Created On",
       "Step Name": "Step Name",
       "Street": "Street",
       "String": "String",
@@ -3745,7 +3751,8 @@
       "Add new extra fields to any entity in the form of data table": "Add new extra fields to any entity in the form of data table",
       "Preferences for generating account numbers for client, loan and savings accounts": "Preferences for generating account numbers for client, loan and savings accounts",
       "“Maker-Checker” principle requires every tasks": "The “Maker-Checker” principle requires every tasks to be completed by two people to reduce the chance of errors and misuse. One person initiates the process and the second completes it.",
-      "NoAuditRecordsFound": "No audit records found for this account."
+      "NoAuditRecordsFound": "No audit records found for this account.",
+      "NoStatusTransitionsFound": "No status transitions found for this client."
     },
     "titles": {
       "Dashboard": "Dashboard",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1510,7 +1510,8 @@
       "AffectedClients": "Clients affectés",
       "Maker": "Créateur",
       "Date": "Date",
-      "MembershipHistory": "Historique de l'adhésion"
+      "MembershipHistory": "Historique de l'adhésion",
+      "StatusTransitions": "Historique des transitions de statut"
     },
     "inputs": {
       "accounting": {
@@ -2635,6 +2636,11 @@
       "Starting date": "Date de début",
       "State / Province": "État/Province",
       "Status": "Statut",
+      "StatusTransitions": "Transitions de statut",
+      "TransitionType": "Type de transition",
+      "Transition": "Transition",
+      "StatusChangedOn": "Statut modifié le",
+      "TransitionCreatedOn": "Créé le",
       "Step Name": "Nom de l'étape",
       "Street": "Rue",
       "String": "Chaîne",
@@ -3721,7 +3727,8 @@
       "Add new extra fields to any entity in the form of data table": "Ajouter de nouveaux champs supplémentaires à n'importe quelle entité sous forme de tableau de données",
       "Preferences for generating account numbers for client, loan and savings accounts": "Préférences de génération de numéros de compte pour les comptes clients, de prêt et d'épargne",
       "“Maker-Checker” principle requires every tasks": "Le principe « Maker-Checker » exige que chaque tâche soit effectuée par deux personnes afin de réduire les risques d'erreurs et de mauvaise utilisation. Une personne lance le processus et la seconde le termine.",
-      "NoAuditRecordsFound": "Aucun enregistrement d'audit trouvé pour ce compte."
+      "NoAuditRecordsFound": "Aucun enregistrement d'audit trouvé pour ce compte.",
+      "NoStatusTransitionsFound": "Aucune transition de statut trouvée pour ce client."
     },
     "titles": {
       "Dashboard": "Tableau de bord",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1511,7 +1511,7 @@
       "Maker": "Créateur",
       "Date": "Date",
       "MembershipHistory": "Historique de l'adhésion",
-      "StatusTransitions": "Historique des transitions de statut"
+      "StatusTransitions": "Historique de statut"
     },
     "inputs": {
       "accounting": {
@@ -2639,6 +2639,7 @@
       "StatusTransitions": "Transitions de statut",
       "TransitionType": "Type de transition",
       "Transition": "Transition",
+      "InitialStatus": "Statut initial",
       "StatusChangedOn": "Statut modifié le",
       "TransitionCreatedOn": "Créé le",
       "Step Name": "Nom de l'étape",
@@ -3051,6 +3052,10 @@
       "Transfer in progress": "Transfert en cours",
       "Transfer on hold": "Transfert en attente",
       "Withdrawn": "Retiré"
+    },
+    "transitionType": {
+      "STATUS": "Statut",
+      "SUB_STATUS": "Sous-statut"
     },
     "dialogContext": {
       "Are you sure you want Unassign Staff": "Êtes-vous sûr de vouloir désassigner le personnel",

--- a/src/assets/translations/sw-KE.json
+++ b/src/assets/translations/sw-KE.json
@@ -2641,6 +2641,7 @@
       "StatusTransitions": "Mabadiliko ya Hali",
       "TransitionType": "Aina ya Mabadiliko",
       "Transition": "Mabadiliko",
+      "InitialStatus": "Hali ya Kwanza",
       "StatusChangedOn": "Hali Ilibadilishwa Tarehe",
       "TransitionCreatedOn": "Imeundwa Tarehe",
       "Step Name": "Jina la Hatua",
@@ -3072,6 +3073,10 @@
       "Transfer in progress": "Uhamisho unaendelea",
       "Transfer on hold": "Uhamisho umesitishwa",
       "Withdrawn": "Imeondolewa"
+    },
+    "transitionType": {
+      "STATUS": "Hali",
+      "SUB_STATUS": "Hali Ndogo"
     },
     "dialogContext": {
       "Are you sure you want Unassign Staff": "Una uhakika unataka kuondoa kazi kwa Mfanyakazi",

--- a/src/assets/translations/sw-KE.json
+++ b/src/assets/translations/sw-KE.json
@@ -1513,7 +1513,8 @@
       "AffectedClients": "Wateja Walioathiriwa",
       "Maker": "Muumba",
       "Date": "Tarehe",
-      "MembershipHistory": "Historia ya Uanachama"
+      "MembershipHistory": "Historia ya Uanachama",
+      "StatusTransitions": "Mabadiliko ya Hali"
     },
     "inputs": {
       "accounting": {
@@ -2637,6 +2638,11 @@
       "Starting Date": "Tarehe ya Kuanza",
       "State / Province": "Jimbo / Mkoa",
       "Status": "Hali",
+      "StatusTransitions": "Mabadiliko ya Hali",
+      "TransitionType": "Aina ya Mabadiliko",
+      "Transition": "Mabadiliko",
+      "StatusChangedOn": "Hali Ilibadilishwa Tarehe",
+      "TransitionCreatedOn": "Imeundwa Tarehe",
       "Step Name": "Jina la Hatua",
       "Street": "Barabara",
       "String": "Mlolongo",
@@ -3743,7 +3749,8 @@
       "Add new extra fields to any entity in the form of data table": "Ongeza sehemu za ziada mpya kwa huluki yoyote katika muundo wa jedwali la data",
       "Preferences for generating account numbers for client, loan and savings accounts": "Mapendeleo ya kuzalisha nambari za akaunti za mteja, mkopo na akiba",
       "“Maker-Checker” principle requires every tasks": "Kanuni ya “Mtengenezaji-Mkaguzi” inahitaji kila kazi ikamilishwe na watu wawili ili kupunguza uwezekano wa makosa na matumizi mabaya. Mtu mmoja anaanzisha mchakato na wa pili anaukamilisha.",
-      "NoAuditRecordsFound": "Hakuna rekodi za ukaguzi zilizopatikana"
+      "NoAuditRecordsFound": "Hakuna rekodi za ukaguzi zilizopatikana",
+      "NoStatusTransitionsFound": "Hakuna mabadiliko ya hali yaliyopatikana kwa mteja huyu."
     },
     "titles": {
       "Dashboard": "Dashibodi",


### PR DESCRIPTION

<img width="3600" height="2180" alt="image" src="https://github.com/user-attachments/assets/980f8ad9-7c03-4c4c-a9e8-a06b4a2fdcde" />
<img width="1800" height="1090" alt="image" src="https://github.com/user-attachments/assets/65fcf108-0d3d-4d36-846d-57069c6fd4f5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a **Status Transitions** tab in client details to view status change history.
  * Includes a paginated table with loading and empty-state handling.
  * Added localized UI text for status transitions (English, French, Swahili).
* **Bug Fixes**
  * Ensures the status transition list loads automatically when entering the tab, with consistent pagination behavior.
* **Chores**
  * Bumped package version to **1.4.12** and updated the release notes entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->