### PR TITLE
HQX-118: Enable persistent filtering while retaining filters after submitting verification entries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
     * Loans & Payments
         * [HQX-276] - Display client deleted loans for visibility
         * [HQX-120] - Display client status transitions
+    * Maker Checker
+        * [HQX-118] - Enable persistent filtering by office name, date range, and other key parameters, while retaining filters after submitting verification entries
 
 ## Version 1.4.10 - Community 1.0.0
 
@@ -73,10 +75,6 @@
     * Clients
         * [CP-3711] - Enable bulk upload of existing farmers to existing groups
 
-<<<<<<< HEAD
-=======
-
->>>>>>> ab20165d (HQX-276 revert version)
 ## Version 1.4.4 - Community 1.0.0
 
     * Clients

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mifosx-web-app",
-  "version": "1.4.12",
+  "version": "1.4.11",
   "description": "MifosX Web App is the default web application built on top of the Fineract platform for the Mifos user community leveraging the popular Angular framework.",
   "keywords": [
     "mifos",

--- a/src/app/tasks/common-directives/base-checker-inbox.component.ts
+++ b/src/app/tasks/common-directives/base-checker-inbox.component.ts
@@ -127,7 +127,7 @@ export abstract class BaseCheckerInboxComponent implements OnDestroy, AfterViewI
 
   viewClient(clientId: string) {
     const dialogRef = this.dialog.open(ClientDetailsDialogComponent, { data: { clientId } });
-    dialogRef.afterClosed().subscribe(result => result === 'confirmed' && this.reload());
+    dialogRef.afterClosed().subscribe(result => result === 'confirmed' && this.refreshCurrentResults());
   }
 
   approveChecker() {
@@ -149,9 +149,13 @@ export abstract class BaseCheckerInboxComponent implements OnDestroy, AfterViewI
       this.tasksService.executeClientKYCAction(el.clientId, action)
     );
     forkJoin(requests).subscribe({
-      next: () => this.reload(),
+      next: () => this.refreshCurrentResults(),
       error: (err) => console.error('Bulk Approve maker checker action failed:', err)
     });
+  }
+
+  private refreshCurrentResults() {
+    this.loadCheckerData();
   }
 
   applyFilter(filterValue: string = '') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification lists now keep filters such as office name and date range after submitting entries.
  * After viewing, approving, or rejecting items, the list refreshes in place to show updated results more smoothly.
* **Documentation**
  * Updated the release notes with the latest Maker Checker change and cleaned up formatting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->