### PR TITLE
fix: comment out dependency on Integration job in QA workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,7 @@ jobs:
 
   QA:
     runs-on: ubuntu-latest
-    needs: Integration
+    # needs: Integration
     if: github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/develop' || contains(github.event.ref, 'refs/heads/hotfix/') || contains(github.event.ref, 'refs/heads/release/')
     environment:
       name: QA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,7 @@ jobs:
   QA:
     runs-on: ubuntu-latest
     # needs: Integration
+    needs: [Build, QualityCheck]
     if: github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/develop' || contains(github.event.ref, 'refs/heads/hotfix/') || contains(github.event.ref, 'refs/heads/release/')
     environment:
       name: QA


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the build workflow so quality checks no longer wait for integration jobs to finish before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->