### PR TITLE
HQX-322 - Show client account against loan account on group general view

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
     * Clients & Groups
         * [HQX-117] - Add standardized configurable kyc failure reasons
         * [HQX-120] - Display client status transitions
+        * [HQX-322] - Show client account number against the loan account on group general view
     * Loans & Payments
         * [HQX-276] - Display client deleted loans for visibility
         * [HQX-120] - Display client status transitions

--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -103,6 +103,11 @@
         <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
       </ng-container>
 
+      <ng-container matColumnDef="Client">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Client' | translate }}.</th>
+        <td mat-cell *matCellDef="let element">{{ element.clientAccountNo }}</td>
+      </ng-container>
+
       <ng-container matColumnDef="Original Loan">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Original Loan' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.originalLoan }}</td>

--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -37,7 +37,7 @@
       </ng-container>
 
       <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}.</th>
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.accountNo }}</td>
       </ng-container>
 
@@ -104,7 +104,7 @@
       </ng-container>
 
       <ng-container matColumnDef="Client">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Client' | translate }}.</th>
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Client' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.clientAccountNo }}</td>
       </ng-container>
 

--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -86,6 +86,15 @@
       [dataSource]="loanAccounts | accountsFilter : 'loan'"
       class="mat-elevation-z1 m-b-30"
     >
+      <ng-container matColumnDef="Client">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Client' | translate }}</th>
+        <td mat-cell *matCellDef="let element">
+          <a [routerLink]="['/clients', element.clientId, 'general']" (click)="$event.stopPropagation()">
+            {{ element.clientAccountNo }}
+          </a>
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="Account No">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}.</th>
         <td mat-cell *matCellDef="let element">
@@ -101,15 +110,6 @@
       <ng-container matColumnDef="Loan Account">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Loan Account' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="Client">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Client' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <a [routerLink]="['/clients', element.clientId, 'general']" (click)="$event.stopPropagation()">
-            {{ element.clientAccountNo }}
-          </a>
-        </td>
       </ng-container>
 
       <ng-container matColumnDef="Original Loan">

--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -105,7 +105,11 @@
 
       <ng-container matColumnDef="Client">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Client' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.clientAccountNo }}</td>
+        <td mat-cell *matCellDef="let element">
+          <a [routerLink]="['/clients', element.clientId, 'general']" (click)="$event.stopPropagation()">
+            {{ element.clientAccountNo }}
+          </a>
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="Original Loan">

--- a/src/app/groups/groups-view/general-tab/general-tab.component.ts
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.ts
@@ -34,9 +34,9 @@ export class GeneralTabComponent implements OnInit {
   clientMemberColumns: string[] = ["Name", "Account No", "Office", "JLG Loan Application"];
   /** Columns to be displayed for open loan accounts table */
   openLoansColumns: string[] = [
+    "Client",
     "Account No",
     "Loan Account",
-    "Client",
     "Original Loan",
     "Loan Balance",
     "Amount Paid",

--- a/src/app/groups/groups-view/general-tab/general-tab.component.ts
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.ts
@@ -36,6 +36,7 @@ export class GeneralTabComponent implements OnInit {
   openLoansColumns: string[] = [
     "Account No",
     "Loan Account",
+    "Client",
     "Original Loan",
     "Loan Balance",
     "Amount Paid",


### PR DESCRIPTION
<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/2197187f-c39f-4879-bacd-a0946b8afe33" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Client** column to **Open Loan Accounts** on the group general view, showing the client account number as a clickable link.
* **Bug Fixes**
  * Updated the **Client Members** table header by removing the trailing period from **“Account No”**.
* **Documentation**
  * Updated **Version 1.4.11 - Community 1.0.0** release notes to include **[HQX-322]** for displaying the client account number alongside the loan account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[HQX-322]: https://oneacrefund.atlassian.net/browse/HQX-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ