### PR TITLE
HQX-215 always show client loans button

### DIFF
--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.html
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.html
@@ -46,7 +46,11 @@
 
         <div fxFlexFill>
           <span fxFlex="40%">Account #:</span>
-          <span fxFlex="60%">{{ viewAccountTransferData.fromAccount.accountNo }}</span>
+          <span fxFlex="60%">
+            <a (click)="navigationURLToAccountFromOnViewTransferData()" class="account-link">
+              {{ viewAccountTransferData.fromAccount.accountNo }}
+            </a>
+          </span>
         </div>
 
         <h3 class="mat-h3" fxFlexFill>Transferred To</h3>
@@ -70,7 +74,11 @@
 
         <div fxFlexFill>
           <span fxFlex="40%">Account #:</span>
-          <span fxFlex="60%">{{ viewAccountTransferData.toAccount.accountNo }}</span>
+          <span fxFlex="60%">
+            <a (click)="navigationURLToAccountToOnViewTransferData()" class="account-link">
+              {{ viewAccountTransferData.toAccount.accountNo }}
+            </a>
+          </span>
         </div>
 
       </div>

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.html
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.html
@@ -47,9 +47,10 @@
         <div fxFlexFill>
           <span fxFlex="40%">Account #:</span>
           <span fxFlex="60%">
-            <a [routerLink]="fromAccountUrl" class="account-link">
+            <a *ngIf="fromAccountUrl; else plainFromAccountNo" [routerLink]="fromAccountUrl" class="account-link">
               {{ viewAccountTransferData.fromAccount.accountNo }}
             </a>
+            <ng-template #plainFromAccountNo>{{ viewAccountTransferData.fromAccount.accountNo }}</ng-template>
           </span>
         </div>
 
@@ -75,9 +76,10 @@
         <div fxFlexFill>
           <span fxFlex="40%">Account #:</span>
           <span fxFlex="60%">
-            <a [routerLink]="toAccountUrl" class="account-link">
+            <a *ngIf="toAccountUrl; else plainToAccountNo" [routerLink]="toAccountUrl" class="account-link">
               {{ viewAccountTransferData.toAccount.accountNo }}
             </a>
+            <ng-template #plainToAccountNo>{{ viewAccountTransferData.toAccount.accountNo }}</ng-template>
           </span>
         </div>
 

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.html
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.html
@@ -47,7 +47,7 @@
         <div fxFlexFill>
           <span fxFlex="40%">Account #:</span>
           <span fxFlex="60%">
-            <a (click)="navigationURLToAccountFromOnViewTransferData()" class="account-link">
+            <a [routerLink]="fromAccountUrl" class="account-link">
               {{ viewAccountTransferData.fromAccount.accountNo }}
             </a>
           </span>
@@ -75,7 +75,7 @@
         <div fxFlexFill>
           <span fxFlex="40%">Account #:</span>
           <span fxFlex="60%">
-            <a (click)="navigationURLToAccountToOnViewTransferData()" class="account-link">
+            <a [routerLink]="toAccountUrl" class="account-link">
               {{ viewAccountTransferData.toAccount.accountNo }}
             </a>
           </span>

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.scss
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.scss
@@ -12,7 +12,7 @@ mat-divider {
 }
 
 .account-link {
-  cursor: pointer;
-  color: #3f51b5;
+  min-width: auto;
+  padding: 0;
   text-decoration: underline;
 }

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.scss
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.scss
@@ -12,7 +12,7 @@ mat-divider {
 }
 
 .account-link {
-  min-width: auto;
+  display: inline-block;
   padding: 0;
   text-decoration: underline;
 }

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.scss
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.scss
@@ -10,3 +10,9 @@ span {
 mat-divider {
   margin: 0 0 0.5em 0;
 }
+
+.account-link {
+  cursor: pointer;
+  color: #3f51b5;
+  text-decoration: underline;
+}

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
@@ -1,5 +1,5 @@
 /** Angular Imports */
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
@@ -1,23 +1,67 @@
 /** Angular Imports */
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'mifosx-view-account-transfer',
   templateUrl: './view-account-transfer.component.html',
   styleUrls: ['./view-account-transfer.component.scss']
 })
-export class ViewAccountTransferComponent {
+export class ViewAccountTransferComponent implements OnDestroy {
 
   viewAccountTransferData: any;
+  private readonly destroy$ = new Subject<void>();
   /**
    * Retrieves the view account transfer data from `resolve`.
    * @param {ActivatedRoute} route Activated Route.
    */
-  constructor(private route: ActivatedRoute) {
-    this.route.data.subscribe((data: { viewAccountTransferData: any }) => {
+  constructor(private route: ActivatedRoute, private router: Router) {
+    this.route.data
+    .pipe(takeUntil(this.destroy$))
+    .subscribe((data: { viewAccountTransferData: any }) => {
       this.viewAccountTransferData = data.viewAccountTransferData;
     });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+    private getAccountUrl(accountTypeCode: string, clientId: string, accountId: string): string | null {
+    const base = `/clients/${clientId}`;
+    if (accountTypeCode === 'accountType.loan') {
+      return `${base}/loans-accounts/${accountId}/general`;
+    }
+    if (accountTypeCode === 'accountType.savings') {
+      return `${base}/savings-accounts/${accountId}/transactions`;
+    }
+    return null;
+  }
+
+  private navigateToAccount(accountTypeCode: string, clientId: string, accountId: string): void {
+    const url = this.getAccountUrl(accountTypeCode, clientId, accountId);
+    if (url) {
+      this.router.navigateByUrl(url);
+    } else {
+      console.warn(`Unsupported account type: ${accountTypeCode}`);
+    }
+  }
+
+  navigationURLToAccountFromOnViewTransferData(): void {
+    const { fromAccountType, fromClient, fromAccount } = this.viewAccountTransferData ?? {};
+    if (fromAccountType && fromClient && fromAccount) {
+      this.navigateToAccount(fromAccountType.code, fromClient.id, fromAccount.id);
+    }
+  }
+
+  navigationURLToAccountToOnViewTransferData(): void {
+    const { toAccountType, toClient, toAccount } = this.viewAccountTransferData ?? {};
+    if (toAccountType && toClient && toAccount) {
+      this.navigateToAccount(toAccountType.code, toClient.id, toAccount.id);
+    }
   }
 
 }

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
@@ -36,7 +36,7 @@ export class ViewAccountTransferComponent implements OnDestroy {
     this.destroy$.complete();
   }
 
-  private getAccountUrl(accountTypeCode: string, clientId: string, accountId: string): string | null {
+  private getAccountUrl(accountTypeCode: string, clientId: string | number, accountId: string | number): string | null {
     const base = `/clients/${clientId}`;
     if (accountTypeCode === 'accountType.loan') {
       return `${base}/loans-accounts/${accountId}/general`;

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
@@ -26,8 +26,8 @@ export class ViewAccountTransferComponent implements OnDestroy {
       .subscribe((data: { viewAccountTransferData: any }) => {
         this.viewAccountTransferData = data.viewAccountTransferData;
         const { fromAccountType, fromClient, fromAccount, toAccountType, toClient, toAccount } = data.viewAccountTransferData;
-        this.fromAccountUrl = this.getAccountUrl(fromAccountType.code, fromClient.id, fromAccount.id);
-        this.toAccountUrl = this.getAccountUrl(toAccountType.code, toClient.id, toAccount.id);
+        this.fromAccountUrl = this.getAccountUrl(fromAccountType?.code, fromClient?.id, fromAccount?.id);
+        this.toAccountUrl = this.getAccountUrl(toAccountType?.code, toClient?.id, toAccount?.id);
       });
   }
 

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
@@ -1,6 +1,6 @@
 /** Angular Imports */
 import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -12,17 +12,23 @@ import { takeUntil } from 'rxjs/operators';
 export class ViewAccountTransferComponent implements OnDestroy {
 
   viewAccountTransferData: any;
+  fromAccountUrl: string | null = null;
+  toAccountUrl: string | null = null;
   private readonly destroy$ = new Subject<void>();
+
   /**
    * Retrieves the view account transfer data from `resolve`.
    * @param {ActivatedRoute} route Activated Route.
    */
-  constructor(private route: ActivatedRoute, private router: Router) {
+  constructor(private route: ActivatedRoute) {
     this.route.data
-    .pipe(takeUntil(this.destroy$))
-    .subscribe((data: { viewAccountTransferData: any }) => {
-      this.viewAccountTransferData = data.viewAccountTransferData;
-    });
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((data: { viewAccountTransferData: any }) => {
+        this.viewAccountTransferData = data.viewAccountTransferData;
+        const { fromAccountType, fromClient, fromAccount, toAccountType, toClient, toAccount } = data.viewAccountTransferData;
+        this.fromAccountUrl = this.getAccountUrl(fromAccountType.code, fromClient.id, fromAccount.id);
+        this.toAccountUrl = this.getAccountUrl(toAccountType.code, toClient.id, toAccount.id);
+      });
   }
 
   ngOnDestroy(): void {
@@ -30,7 +36,7 @@ export class ViewAccountTransferComponent implements OnDestroy {
     this.destroy$.complete();
   }
 
-    private getAccountUrl(accountTypeCode: string, clientId: string, accountId: string): string | null {
+  private getAccountUrl(accountTypeCode: string, clientId: string, accountId: string): string | null {
     const base = `/clients/${clientId}`;
     if (accountTypeCode === 'accountType.loan') {
       return `${base}/loans-accounts/${accountId}/general`;
@@ -39,29 +45,6 @@ export class ViewAccountTransferComponent implements OnDestroy {
       return `${base}/savings-accounts/${accountId}/transactions`;
     }
     return null;
-  }
-
-  private navigateToAccount(accountTypeCode: string, clientId: string, accountId: string): void {
-    const url = this.getAccountUrl(accountTypeCode, clientId, accountId);
-    if (url) {
-      this.router.navigateByUrl(url);
-    } else {
-      console.warn(`Unsupported account type: ${accountTypeCode}`);
-    }
-  }
-
-  navigationURLToAccountFromOnViewTransferData(): void {
-    const { fromAccountType, fromClient, fromAccount } = this.viewAccountTransferData ?? {};
-    if (fromAccountType && fromClient && fromAccount) {
-      this.navigateToAccount(fromAccountType.code, fromClient.id, fromAccount.id);
-    }
-  }
-
-  navigationURLToAccountToOnViewTransferData(): void {
-    const { toAccountType, toClient, toAccount } = this.viewAccountTransferData ?? {};
-    if (toAccountType && toClient && toAccount) {
-      this.navigateToAccount(toAccountType.code, toClient.id, toAccount.id);
-    }
   }
 
 }

--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -105,7 +105,7 @@
     </div>
     <div fxLayout="column" fxFlex="50%">
       <div fxLayout="row" fxLayoutAlign="flex-end">
-        <div *ngIf="(loanAccounts | accountsFilter : 'loan' : 'closed')?.length || (loanAccounts | accountsFilter : 'loan' : 'deleted')?.length" class="action-button m-b-10">
+        <div class="action-button m-b-10">
           <mat-button-toggle-group [(ngModel)]="loanAccountsView" (change)="onLoanAccountsViewChange($event)" class="mat-primary">
             <mat-button-toggle value="active">{{ 'labels.status.Active' | translate }}</mat-button-toggle>
             <mat-button-toggle value="closed">{{ 'labels.status.Closed' | translate }}</mat-button-toggle>


### PR DESCRIPTION
## Description
- Always show client loans toggle button
- View affected accounts details from COCA transaction

## Changes Included in PR
- [HQX-215 - Improve deleted loan visibility](https://oneacrefund.atlassian.net/browse/HQX-215)


## Screenshots, if any
<img width="1301" height="376" alt="Screenshot 2026-07-07 at 15 06 43" src="https://github.com/user-attachments/assets/9cd3a256-5479-43f8-992c-cd9b2c62df4f" />

<img width="1275" height="680" alt="Screenshot 2026-07-07 at 15 06 57" src="https://github.com/user-attachments/assets/e0828708-90be-4b06-8ee9-09c8c1e24145" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made the “From” and “To” account numbers on the transfer details page clickable when link targets are available, so you can navigate directly to the related accounts.
  * The loan accounts action area now always renders in the client overview.
* **Bug Fixes**
  * Improved transfer page navigation by generating link targets safely and cleaning up route-data subscriptions on component teardown.
* **Style**
  * Updated clickable account numbers to use dedicated link styling (underlined).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->