### PR TITLE
fix FNG-395: Add country filter to KYC verification list retrieval

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,7 @@
         * [HQX-120] - Display client status transitions
     * Maker Checker
         * [HQX-118] - Enable persistent filtering by office name, date range, and other key parameters, while retaining filters after submitting verification entries
-        * [FNG-395] - Add country filter on Client KYC Verifaction list retrieval
+        * [FNG-395] - Add country filter on Client KYC Verification list retrieval
 
 ## Version 1.4.10 - Community 1.0.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
         * [HQX-120] - Display client status transitions
     * Maker Checker
         * [HQX-118] - Enable persistent filtering by office name, date range, and other key parameters, while retaining filters after submitting verification entries
+        * [FNG-395] - Add country filter on Client KYC Verifaction list retrieval
 
 ## Version 1.4.10 - Community 1.0.0
 

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -68,6 +68,7 @@ export class ClientsService {
     limit: number,
     countryId: string,
     subStatus?: string,
+    displayName?: string,
   ): Observable<any> {
     let httpParams = new HttpParams()
       .set('offset', offset.toString())
@@ -79,6 +80,9 @@ export class ClientsService {
 
       if(subStatus) {
         httpParams = httpParams.set('subStatus', subStatus);
+      }
+      if(displayName) {
+        httpParams = httpParams.set('displayName', displayName);
       }
     return this.http.get('/clients', { params: httpParams });
   }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/client-failed-kyc/client-failed-kyc.datasource.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/client-failed-kyc/client-failed-kyc.datasource.ts
@@ -45,7 +45,12 @@ export class ClientFailedKYCDataSource implements DataSource<any> {
     const ob = orderBy || 'last_kyc_approval_on_date';
     const so = (sortOrder || 'ASC').toUpperCase();
 
-    this.clientsService.getClients(ob, so, pageIndex * limit, limit, this.subStatus).subscribe((clients: any) => {
+    const countryId = this.settingsService.getSelectedCountry()?.id;
+    const clientsCall$ = countryId
+      ? this.clientsService.getClientsByCountry(ob, so, pageIndex * limit, limit, countryId, this.subStatus)
+      : this.clientsService.getClients(ob, so, pageIndex * limit, limit, this.subStatus);
+
+    clientsCall$.subscribe((clients: any) => {
       const items = (clients?.pageItems ?? []).filter((c: any) => c?.status?.value !== 'Closed');
       this.recordsSubject.next(clients?.totalFilteredRecords ?? items.length);
       this.clientsSubject.next(items);

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/client-failed-kyc/client-failed-kyc.datasource.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/client-failed-kyc/client-failed-kyc.datasource.ts
@@ -91,7 +91,11 @@ export class ClientFailedKYCDataSource implements DataSource<any> {
     const ob = orderBy || 'last_kyc_approval_on_date';
     const so = (sortOrder || 'ASC').toUpperCase();
     const offset = pageIndex * limit;
-    this.clientsService.getClients(ob, so, offset, limit, this.subStatus, filter).subscribe((clients: any) => {
+    const countryId = this.settingsService.getSelectedCountry()?.id;
+    const clientsCall$ = countryId
+      ? this.clientsService.getClientsByCountry(ob, so, offset, limit, countryId, this.subStatus, filter)
+      : this.clientsService.getClients(ob, so, offset, limit, this.subStatus, filter);
+    clientsCall$.subscribe((clients: any) => {
 
       const items = (clients?.pageItems ?? []).filter((c: any) => c?.status?.value !== 'Closed');
       this.recordsSubject.next(clients?.totalFilteredRecords ?? items.length);

--- a/src/app/tasks/common-directives/base-checker-inbox.component.ts
+++ b/src/app/tasks/common-directives/base-checker-inbox.component.ts
@@ -80,6 +80,8 @@ export abstract class BaseCheckerInboxComponent implements OnDestroy, AfterViewI
     const pageSize = this.paginator ? this.paginator.pageSize : this.pageSize;
     const dateFormat = "dd MMMM yyyy";
 
+    const countryId = this.settingsService.getSelectedCountry()?.id;
+
     const params = {
       ...cleanForm,
       offset: pageIndex * pageSize,
@@ -88,7 +90,8 @@ export abstract class BaseCheckerInboxComponent implements OnDestroy, AfterViewI
       sortOrder: this.sort?.direction || undefined,
       includeClientHierarchyPath: this.includeOUPath ? this.includeOUPath.checked : true,
       dateFrom: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.dateFrom, dateFormat),
-      dateTo: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.dateTo, dateFormat)
+      dateTo: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.dateTo, dateFormat),
+      ...(countryId ? { countryId } : {})
     };
 
     this.tasksService.getClientKYCApprovals(params)

--- a/src/app/tasks/common-resolvers/getClientPendingReVerificationEntries.resolver.ts
+++ b/src/app/tasks/common-resolvers/getClientPendingReVerificationEntries.resolver.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 
 /** Custom Services */
 import { TasksService } from '../tasks.service';
+import { SettingsService } from 'app/settings/settings.service';
 
 /**
  * Client Verification Data resolver.
@@ -17,20 +18,24 @@ export class GetClientPendingReVerificationEntries implements Resolve<Object> {
   /**
    * @param {TasksService} tasksService Tasks service.
    */
-  constructor(private readonly tasksService: TasksService) {}
+  constructor(private readonly tasksService: TasksService, private readonly settingsService: SettingsService) {}
 
   /**
    * Returns the maker checker data.
    * @returns {Observable<any>}
    */
   resolve(): Observable<any> {
-    const searchData = {
+    const countryId = this.settingsService.getSelectedCountry()?.id;
+    const searchData: any = {
       clientSubStatus: "clientSubStatusType.pending_re_verification",
       includeClientHierarchyPath: true,
       paged: true,
       offset: 0,
       limit: 10
     };
+    if (countryId) {
+      searchData.countryId = countryId;
+    }
     return this.tasksService.getClientKYCApprovals(searchData);
   }
 

--- a/src/app/tasks/common-resolvers/getClientVerificationEntries.resolver.ts
+++ b/src/app/tasks/common-resolvers/getClientVerificationEntries.resolver.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 
 /** Custom Services */
 import { TasksService } from '../tasks.service';
+import { SettingsService } from 'app/settings/settings.service';
 
 /**
  * Client Verification Data resolver.
@@ -17,20 +18,24 @@ export class GetClientVerificationEntries implements Resolve<Object> {
   /**
    * @param {TasksService} tasksService Tasks service.
    */
-  constructor(private readonly tasksService: TasksService) {}
+  constructor(private readonly tasksService: TasksService, private readonly settingsService: SettingsService) {}
 
   /**
    * Returns the maker checker data.
    * @returns {Observable<any>}
    */
   resolve(): Observable<any> {
-    const searchData = {
+    const countryId = this.settingsService.getSelectedCountry()?.id;
+    const searchData: any = {
       clientSubStatus: 'clientSubStatusType.auto_verified',
       includeClientHierarchyPath: true,
       paged: true,
       offset: 0,
       limit: 10
     };
+    if (countryId) {
+      searchData.countryId = countryId;
+    }
     return this.tasksService.getClientKYCApprovals(searchData);
   }
 }


### PR DESCRIPTION

## Description
Add country filter to KYC verification list retrieval


## Screenshots
<img width="1508" height="645" alt="image" src="https://github.com/user-attachments/assets/d650ebf8-acff-4ab4-8e6d-90c8e3f191cb" />

<img width="1487" height="616" alt="image" src="https://github.com/user-attachments/assets/150af9fb-4345-4dee-8f83-a15cb65a19ca" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added country-based filtering to Client KYC verification and related maker-checker lists when a country is selected.
  * List retrieval now respects the currently selected country across pending re-verification and verification views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->