### PR TITLE
chore: add catalog-info.yaml for Backstage registration

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,33 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: fineract-ui
+  description: UI component for Fineract for managing clients, offices, loans and client payments
+  links:
+    - title: Production URL
+      url: https://loans.oneacrefund.org/
+      icon: web
+    - title: UAT URL
+      url: https://loans.uat.oneacrefund.org/
+      icon: web
+    - title: QA URL
+      url: https://loans.qa.oneacrefund.org/
+      icon: web
+    - title: Dev URL
+      url: https://loans.dev.oneacrefund.org/
+      icon: web
+  annotations:
+    backstage.io/source-location: url:https://github.com/one-acre-fund/fineract-frontend-v2/tree/main
+    sonarqube.org/project-key: one-acre-fund_one-acre-fund_fineract-frontend-v2
+    github.com/project-slug: one-acre-fund/fineract-frontend-v2
+    sentry.io/project-slug: fineract-ui
+spec:
+  type: website
+  lifecycle: production
+  owner: group:one-acre-fund/credits-and-payments
+  system: system:default/clif
+  dependsOn:
+    - component:default/fineract
+    - component:default/keycloak
+    - component:default/matomo
+    - component:default/elastic-apm

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,7 +18,7 @@ metadata:
       icon: web
   annotations:
     backstage.io/source-location: url:https://github.com/one-acre-fund/fineract-frontend-v2/tree/main
-    sonarqube.org/project-key: one-acre-fund_one-acre-fund_fineract-frontend-v2
+    sonarqube.org/project-key: one-acre-fund_fineract-frontend-v2
     github.com/project-slug: one-acre-fund/fineract-frontend-v2
     sentry.io/project-slug: fineract-ui
 spec:
@@ -29,5 +29,3 @@ spec:
   dependsOn:
     - component:default/fineract
     - component:default/keycloak
-    - component:default/matomo
-    - component:default/elastic-apm


### PR DESCRIPTION
## Add Backstage Catalog Info

This PR adds a `catalog-info.yaml` at the root of the repository to register
**fineract-ui** in the Backstage software catalog.

### Component details
- **Name:** fineract-ui
- **Type:** website
- **Owner:** group:one-acre-fund/credits-and-payments
- **System:** system:default/clif

### Dependencies
- Redis: 
- PostgreSQL: 
- RabbitMQ: 

Once this PR is merged, register the component in the catalog by visiting
the Backstage catalog import page and providing the path `/catalog-info.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation / Configuration**
  * Updated the Backstage catalog entry for **Fineract UI** with environment-specific links (Production, UAT, QA, Dev), ownership/system metadata, and external service annotations.
  * Corrected the SonarQube project key for the component.
  * Adjusted the component’s declared dependencies to include only the intended core services (removing prior telemetry-related catalog dependencies).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->